### PR TITLE
Implement PRD-311 plugin packaging and device auth

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "personal",
+  "interface": {
+    "displayName": "Personal"
+  },
+  "plugins": [
+    {
+      "name": "miru-code",
+      "source": {
+        "source": "local",
+        "path": "."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,10 +5,11 @@
   },
   "plugins": [
     {
-      "name": "miru-code",
+      "name": "miru",
       "source": {
-        "source": "local",
-        "path": "."
+        "source": "url",
+        "url": "https://github.com/takara-ai/miru-code.git",
+        "ref": "main"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "miru",
+  "description": "Semantic code search for coding agents. Find code by meaning, not grep.",
+  "owner": {
+    "name": "Takara",
+    "url": "https://github.com/takara-ai"
+  },
+  "plugins": [
+    {
+      "name": "miru",
+      "description": "Repo-aware semantic code search with MCP and first-use device authentication.",
+      "source": "./",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "miru",
+  "version": "1.0.5",
+  "description": "Semantic code search for coding agents. Find code by meaning, not grep.",
+  "author": {
+    "name": "Takara",
+    "url": "https://github.com/takara-ai"
+  },
+  "skills": [
+    "./skills/"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "miru-code",
+  "version": "1.0.5",
+  "description": "Miru (見る) — hybrid code search for agents. Bun, TypeScript, Takara embeddings.",
+  "author": {
+    "name": "Takara",
+    "url": "https://github.com/takara-ai"
+  },
+  "homepage": "https://takara.ai",
+  "repository": "https://github.com/takara-ai/miru-code",
+  "license": "MIT",
+  "keywords": ["code-search", "semantic-search", "mcp", "agents", "takara"],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Miru Code",
+    "shortDescription": "Semantic code search for coding agents.",
+    "longDescription": "Miru adds repo-aware semantic search to Codex via MCP and guides agents away from grep-style exploration.",
+    "developerName": "Takara",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Read"],
+    "websiteURL": "https://takara.ai",
+    "defaultPrompt": [
+      "Find where auth is wired in this repo.",
+      "Locate similar code paths for this file and line.",
+      "Search this project by behavior instead of grep."
+    ],
+    "brandColor": "#0F766E"
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "miru-code",
+  "name": "miru",
   "version": "1.0.5",
   "description": "Miru (見る) — hybrid code search for agents. Bun, TypeScript, Takara embeddings.",
   "author": {
@@ -12,7 +12,7 @@
   "keywords": ["code-search", "semantic-search", "mcp", "agents", "takara"],
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "Miru Code",
+    "displayName": "Miru Code Search",
     "shortDescription": "Semantic code search for coding agents.",
     "longDescription": "Miru adds repo-aware semantic search to Codex via MCP and guides agents away from grep-style exploration.",
     "developerName": "Takara",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -10,6 +10,7 @@
   "repository": "https://github.com/takara-ai/miru-code",
   "license": "MIT",
   "keywords": ["code-search", "semantic-search", "mcp", "agents", "takara"],
+  "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Miru Code Search",
@@ -17,7 +18,7 @@
     "longDescription": "Miru adds repo-aware semantic search to Codex via MCP and guides agents away from grep-style exploration.",
     "developerName": "Takara",
     "category": "Productivity",
-    "capabilities": ["Interactive", "Read"],
+    "capabilities": ["Instructions", "Interactive"],
     "websiteURL": "https://takara.ai",
     "defaultPrompt": [
       "Find where auth is wired in this repo.",

--- a/.cursor/rules/miru-code-search.mdc
+++ b/.cursor/rules/miru-code-search.mdc
@@ -1,0 +1,20 @@
+---
+description: Miru MCP is the default for conceptual code exploration
+alwaysApply: true
+---
+
+# Miru Code Search
+
+DO NOT use Grep, Glob, SemanticSearch, or broad file reads to explore how code works when Miru MCP is available.
+
+Search returns compact snippets (~±15 lines around the best match). When a hit has `truncated: true`, call `expand` with `file_path` and `anchor_line` (or `start_line`) instead of rereading the whole file.
+
+Use Miru MCP tools:
+- `search` — one call per question; pass project root as `repo`
+- `expand` — more context in the same file when `truncated: true`
+- `find_related` — similar code in other files
+
+Allowed native-tool exceptions:
+- exact literal lookups such as env vars or quoted strings
+- reading a file Miru already identified so it can be edited
+- searching outside the indexed repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Cursor
 .cursor
+!.cursor/
+!.cursor/rules/
+!.cursor/rules/miru-code-search.mdc
 
 # dependencies (bun install)
 node_modules

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "miru": {
+      "type": "stdio",
+      "command": "bunx",
+      "args": ["@takara-ai/miru-code"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Your AI agent finds the code it needs in 60% fewer tokens.
 
-**Requires:** [Bun](https://bun.sh) 1.1+ · [Takara API key](https://takara.ai)
+**Requires:** [Bun](https://bun.sh) 1.1+ · Takara credentials
 
 ## Install
 
@@ -10,20 +10,21 @@ Your AI agent finds the code it needs in 60% fewer tokens.
 bun add -g @takara-ai/miru-code
 ```
 
-## Set up API key
+## Set up credentials
 
 ```bash
 miru setup
 ```
 
-Validates your key and saves it locally. Skip this if you prefer — `miru search` or `miru install` will prompt on first run.
+Interactive `miru setup` defaults to device-code login and saves the resulting credentials locally. Manual bearer-token entry is still available with `--key`. If credentials are missing, the interactive MCP/plugin path can bootstrap the same device flow automatically on first use.
 
 ```bash
-miru setup --key YOUR_TOKEN   # non-interactive
-miru setup --clear            # remove stored key
+miru setup --device           # explicit device-code login
+miru setup --key YOUR_TOKEN   # store a bearer token directly
+miru setup --clear            # remove stored credentials
 ```
 
-MCP loads your key from `credentials.json` automatically — no env block needed in MCP config.
+Miru stores versioned credentials in `credentials.json` and automatically loads or refreshes them for MCP and CLI use. `TAKARA_API_KEY` still overrides stored credentials when set explicitly.
 
 ## Add to your IDE
 
@@ -180,10 +181,9 @@ Set `MIRU_AST_CHUNKING=0` to disable AST and use structural → lines only.
 
 ## CLI reference
 
-
 | Command                                  | Purpose                                                                           |
-| ---------------------------------------- | --------------------------------------------------------------------------------- |
-| `miru setup`                             | Store API key                                                                     |
+| ----------------------------------------- | --------------------------------------------------------------------------------- |
+| `miru setup`                             | Authenticate and store credentials                                                |
 | `miru install`                           | Configure IDE (global)                                                            |
 | `miru uninstall`                         | Remove IDE config                                                                     |
 | `miru search <query> [path]`             | Search (`-k N`, `--content`, `--json`)                                            |
@@ -335,7 +335,7 @@ Override with `MIRU_BENCHMARK_HISTORY_PATH`. Append-only JSONL of compact token 
 
 For benchmark mode, set `"args": ["--benchmark"]` (or append that flag). Prefer `miru benchmark on` after a normal install — it updates every agent config.
 
-Run `miru setup` once so the server can load your key from `credentials.json`.
+Run `miru setup` once so the server can load credentials from `credentials.json`. If the MCP server starts in an interactive terminal without stored credentials, it will start device login automatically.
 
 Use `bunx` + `@takara-ai/miru-code` if `miru` is not global. Wrapper key varies by IDE (`mcpServers`, `servers`, or `mcp`).
 
@@ -350,6 +350,16 @@ bun test && bun run typecheck
 Local MCP: `"command": "bun", "args": ["/path/to/miru-code/src/cli.ts"]`
 
 `miru help` / setup print a framed wordmark on color terminals (`MIRU_QUIET=1` for subtitle only). Crane art lives in `src/brand-banner.ts`; regenerate with `bun run scripts/render-crane-art.ts` (ImageMagick). The crane is a registered mark of Takara.ai Ltd.
+
+## Codex plugin in this repo
+
+This repo includes a repo-local Codex plugin:
+
+- `.codex-plugin/plugin.json`
+- `.mcp.json`
+- `.agents/plugins/marketplace.json`
+
+The plugin intentionally launches the published package with `bunx @takara-ai/miru-code` instead of the checked-out source tree, so local source edits here do not affect the Codex plugin until a new package version is published.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ miru uninstall   # remove miru config
 | Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               |
 | Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  |
 
+### Plugin packaging
+
+This repo now includes plugin packaging for:
+
+- Codex: `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`
+- Claude Code: `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
+- Cursor: `plugin.json` and `.cursor/rules/miru-code-search.mdc`
+
+Current limitation:
+
+- these plugin manifests still launch the published Miru runtime through `bunx @takara-ai/miru-code`
+- that means local source edits do not affect plugin behavior until a package version is published
+- and a fully self-contained “no Bun required” plugin install is still future work
+
+### Search hooks
 
 Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet.
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "miru",
+  "version": "1.0.5",
+  "description": "Semantic code search for coding agents. Find code by meaning, not grep.",
+  "author": {
+    "name": "Takara",
+    "url": "https://github.com/takara-ai"
+  },
+  "homepage": "https://takara.ai",
+  "repository": "https://github.com/takara-ai/miru-code",
+  "license": "MIT",
+  "keywords": [
+    "code-search",
+    "semantic-search",
+    "mcp",
+    "agents",
+    "takara"
+  ],
+  "category": "Productivity",
+  "tags": [
+    "mcp",
+    "semantic-search",
+    "developer-tools"
+  ],
+  "skills": "./skills/",
+  "rules": "./.cursor/rules/miru-code-search.mdc",
+  "mcpServers": "./.mcp.json"
+}

--- a/skills/miru/SKILL.md
+++ b/skills/miru/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: miru
+description: Use Miru Code Search when the user asks where code lives, how behavior is wired, or what related code paths exist in a repo. Prefer this for conceptual code exploration over grep, glob, or broad file reads.
+---
+
+# Miru Code Search
+
+Use Miru MCP as the default code-exploration path when it is available.
+
+## When to use it
+
+Use Miru when the user asks things like:
+
+- where is auth wired?
+- what code handles this behavior?
+- find related code paths for this file and line
+- search the repo by meaning instead of grep
+
+Do not use Miru for exact literal lookups such as:
+
+- env var names
+- exact error codes
+- quoted string matches
+
+## Workflow
+
+1. Call `search` once with `repo` set to the project root.
+2. If a result has `truncated: true`, call `expand` with `file_path` and `anchor_line` (or `start_line`).
+3. Use `find_related` only for similar code in other files.
+4. Read files directly only after Miru has already identified the relevant path.
+
+## Tool preference
+
+- Prefer Miru `search` over grep/glob/bash exploration for conceptual questions.
+- Prefer Miru `expand` over rereading whole files when a hit is truncated.
+- Prefer Miru `find_related` over repeated search paraphrases when tracing similar logic.

--- a/src/auth/device.ts
+++ b/src/auth/device.ts
@@ -1,0 +1,262 @@
+import { envFirstString } from "../env.ts";
+import type { StoredDeviceCodeCredentials } from "./types.ts";
+
+const DEFAULT_AUTH_BASE_URL = "https://auth.takara.ai";
+const DEFAULT_DEVICE_CODE_PATH = "/oauth/device/code";
+const DEFAULT_TOKEN_PATH = "/oauth/token";
+const DEFAULT_CLIENT_ID = "miru-code";
+const EXPIRY_SKEW_MS = 60_000;
+
+export interface DeviceAuthConfig {
+  baseUrl: string;
+  clientId: string;
+  scope?: string;
+  audience?: string;
+  deviceCodePath: string;
+  tokenPath: string;
+}
+
+export interface DeviceAuthorizationStart {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+  expiresIn: number;
+  interval: number;
+}
+
+export interface DeviceAuthorizationTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: string;
+  tokenType?: string;
+  scope?: string;
+}
+
+interface OAuthTokenSuccess {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+interface OAuthTokenError {
+  error?: string;
+  error_description?: string;
+}
+
+export function resolveDeviceAuthConfig(): DeviceAuthConfig {
+  return {
+    baseUrl: envFirstString(["MIRU_AUTH_BASE_URL"], DEFAULT_AUTH_BASE_URL).replace(/\/$/, ""),
+    clientId: envFirstString(["MIRU_AUTH_CLIENT_ID"], DEFAULT_CLIENT_ID),
+    scope: process.env.MIRU_AUTH_SCOPE?.trim() || undefined,
+    audience: process.env.MIRU_AUTH_AUDIENCE?.trim() || undefined,
+    deviceCodePath: process.env.MIRU_DEVICE_CODE_PATH?.trim() || DEFAULT_DEVICE_CODE_PATH,
+    tokenPath: process.env.MIRU_TOKEN_PATH?.trim() || DEFAULT_TOKEN_PATH,
+  };
+}
+
+function resolveUrl(baseUrl: string, path: string): string {
+  return new URL(path, `${baseUrl}/`).toString();
+}
+
+function tokenExpiryToIso(expiresIn?: number): string | undefined {
+  if (expiresIn == null || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    return undefined;
+  }
+  return new Date(Date.now() + expiresIn * 1000).toISOString();
+}
+
+function normalizeTokenSuccess(payload: OAuthTokenSuccess): DeviceAuthorizationTokens {
+  return {
+    accessToken: payload.access_token,
+    refreshToken: payload.refresh_token,
+    expiresAt: tokenExpiryToIso(payload.expires_in),
+    tokenType: payload.token_type,
+    scope: payload.scope,
+  };
+}
+
+function parseTokenError(payload: OAuthTokenError): string {
+  const code = payload.error?.trim();
+  const description = payload.error_description?.trim();
+  if (code && description) {
+    return `${code}: ${description}`;
+  }
+  return code || description || "unknown_error";
+}
+
+async function postForm(
+  url: string,
+  body: URLSearchParams,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  return fetchImpl(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+}
+
+export async function startDeviceAuthorization(
+  options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
+): Promise<DeviceAuthorizationStart> {
+  const config = options?.config ?? resolveDeviceAuthConfig();
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const body = new URLSearchParams({ client_id: config.clientId });
+  if (config.scope) {
+    body.set("scope", config.scope);
+  }
+  if (config.audience) {
+    body.set("audience", config.audience);
+  }
+
+  const response = await postForm(
+    resolveUrl(config.baseUrl, config.deviceCodePath),
+    body,
+    fetchImpl,
+  );
+  const text = await response.text();
+  const payload = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  if (!response.ok) {
+    throw new Error(`Device authorization failed: ${text || response.statusText}`);
+  }
+
+  const deviceCode = String(payload.device_code ?? "").trim();
+  const userCode = String(payload.user_code ?? "").trim();
+  const verificationUri = String(
+    payload.verification_uri ?? payload.verification_url ?? "",
+  ).trim();
+  if (!deviceCode || !userCode || !verificationUri) {
+    throw new Error("Device authorization response was missing required fields.");
+  }
+
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    verificationUriComplete:
+      typeof payload.verification_uri_complete === "string"
+        ? payload.verification_uri_complete
+        : undefined,
+    expiresIn:
+      typeof payload.expires_in === "number" && payload.expires_in > 0 ? payload.expires_in : 600,
+    interval:
+      typeof payload.interval === "number" && payload.interval >= 0 ? payload.interval : 5,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function pollDeviceAuthorization(
+  start: DeviceAuthorizationStart,
+  options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
+): Promise<DeviceAuthorizationTokens> {
+  const config = options?.config ?? resolveDeviceAuthConfig();
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const deadline = Date.now() + start.expiresIn * 1000;
+  let intervalMs = start.interval * 1000;
+
+  while (Date.now() < deadline) {
+    await sleep(intervalMs);
+
+    const body = new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: start.deviceCode,
+      client_id: config.clientId,
+    });
+    const response = await postForm(resolveUrl(config.baseUrl, config.tokenPath), body, fetchImpl);
+    const text = await response.text();
+    const payload = text ? (JSON.parse(text) as OAuthTokenSuccess | OAuthTokenError) : {};
+
+    if (response.ok) {
+      const success = payload as OAuthTokenSuccess;
+      if (!success.access_token?.trim()) {
+        throw new Error("Device login succeeded but did not return an access token.");
+      }
+      return normalizeTokenSuccess(success);
+    }
+
+    const error = (payload as OAuthTokenError).error;
+    if (error === "authorization_pending") {
+      continue;
+    }
+    if (error === "slow_down") {
+      intervalMs += 5_000;
+      continue;
+    }
+    if (error === "access_denied") {
+      throw new Error("Device login was denied.");
+    }
+    if (error === "expired_token") {
+      throw new Error("Device login expired before it was completed.");
+    }
+    throw new Error(`Device login failed: ${parseTokenError(payload as OAuthTokenError)}`);
+  }
+
+  throw new Error("Device login timed out before it was completed.");
+}
+
+export async function refreshDeviceAuthorization(
+  credentials: StoredDeviceCodeCredentials,
+  options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
+): Promise<DeviceAuthorizationTokens> {
+  if (!credentials.refresh_token?.trim()) {
+    throw new Error("Stored device credentials cannot be refreshed because no refresh token exists.");
+  }
+
+  const config = options?.config ?? resolveDeviceAuthConfig();
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: credentials.refresh_token,
+    client_id: config.clientId,
+  });
+  const response = await postForm(resolveUrl(config.baseUrl, config.tokenPath), body, fetchImpl);
+  const text = await response.text();
+  const payload = text ? (JSON.parse(text) as OAuthTokenSuccess | OAuthTokenError) : {};
+
+  if (!response.ok) {
+    throw new Error(`Device token refresh failed: ${parseTokenError(payload as OAuthTokenError)}`);
+  }
+
+  const success = payload as OAuthTokenSuccess;
+  if (!success.access_token?.trim()) {
+    throw new Error("Token refresh succeeded but did not return an access token.");
+  }
+
+  return normalizeTokenSuccess({
+    ...success,
+    refresh_token: success.refresh_token ?? credentials.refresh_token,
+  });
+}
+
+export function deviceCredentialsNeedRefresh(credentials: StoredDeviceCodeCredentials): boolean {
+  if (!credentials.expires_at) {
+    return false;
+  }
+  const expiresAt = Date.parse(credentials.expires_at);
+  if (!Number.isFinite(expiresAt)) {
+    return true;
+  }
+  return expiresAt <= Date.now() + EXPIRY_SKEW_MS;
+}
+
+export function openBrowserForDeviceLogin(url: string): boolean {
+  const command =
+    process.platform === "darwin"
+      ? ["open", url]
+      : process.platform === "win32"
+        ? ["cmd", "/c", "start", "", url]
+        : ["xdg-open", url];
+  try {
+    const proc = Bun.spawn(command, { stdout: "ignore", stderr: "ignore" });
+    void proc.exited;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/auth/providers.ts
+++ b/src/auth/providers.ts
@@ -1,0 +1,117 @@
+import { hint, info, warn, writeStderr } from "../cli-ui.ts";
+import { promptHidden } from "../prompt.ts";
+import { Spinner } from "../spinner.ts";
+import { validateEmbeddingApiKey } from "../embeddings/validate.ts";
+import { promptConfirm } from "../installer/prompt.ts";
+import {
+  openBrowserForDeviceLogin,
+  pollDeviceAuthorization,
+  startDeviceAuthorization,
+} from "./device.ts";
+import type { AuthenticatedCredentials } from "./types.ts";
+
+export type AuthMode = "api_key" | "device_code";
+
+export interface AuthenticateOptions {
+  apiKey?: string;
+  device?: boolean;
+  skipValidation?: boolean;
+  allowManualFallback?: boolean;
+  interactive?: boolean;
+}
+
+async function promptApiKey(): Promise<string> {
+  let key = "";
+  while (!key) {
+    key = await promptHidden("Takara API key (input hidden): ", process.stderr);
+    if (!key) {
+      warn("API key cannot be empty.");
+    }
+  }
+  return key;
+}
+
+async function resolveAuthMode(options: AuthenticateOptions): Promise<AuthMode> {
+  if (options.apiKey) {
+    return "api_key";
+  }
+  if (options.device) {
+    return "device_code";
+  }
+  if (!options.interactive) {
+    throw new Error("Choose an auth mode with `miru setup --device` or `miru setup --key TOKEN`.");
+  }
+  writeStderr("");
+  info("Choose how to authenticate.");
+  const useDevice = await promptConfirm("Use device code login?", true);
+  return useDevice ? "device_code" : "api_key";
+}
+
+async function authenticateWithApiKey(options: AuthenticateOptions): Promise<AuthenticatedCredentials> {
+  const apiKey = options.apiKey ?? (await promptApiKey());
+  if (!options.skipValidation) {
+    const spinner = new Spinner("Validating API key");
+    spinner.start();
+    const result = await validateEmbeddingApiKey({ apiKey });
+    if (!result.valid) {
+      spinner.stop();
+      throw new Error(result.message);
+    }
+    spinner.succeed("API key validated");
+  }
+  return { kind: "api_key", apiKey };
+}
+
+async function authenticateWithDeviceCode(
+  options: AuthenticateOptions,
+): Promise<AuthenticatedCredentials> {
+  const start = await startDeviceAuthorization();
+  writeStderr("");
+  info(`Open ${start.verificationUri}`);
+  hint(`Code: ${start.userCode}`);
+  if (start.verificationUriComplete) {
+    hint(`Direct link: ${start.verificationUriComplete}`);
+  }
+  if (options.interactive) {
+    const shouldOpenBrowser =
+      process.env.MIRU_OPEN_BROWSER === undefined || process.env.MIRU_OPEN_BROWSER === "1";
+    if (shouldOpenBrowser && openBrowserForDeviceLogin(start.verificationUriComplete ?? start.verificationUri)) {
+      hint("Opened the verification page in your browser.");
+    }
+  }
+
+  const spinner = new Spinner("Waiting for device authorization");
+  spinner.start();
+  try {
+    const tokens = await pollDeviceAuthorization(start);
+    spinner.succeed("Device login completed");
+    return {
+      kind: "device_code",
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      tokenType: tokens.tokenType,
+      scope: tokens.scope,
+    };
+  } catch (err) {
+    spinner.stop();
+    if (options.allowManualFallback && options.interactive) {
+      warn(err instanceof Error ? err.message : String(err));
+      const fallback = await promptConfirm("Enter an API key instead?", true);
+      if (fallback) {
+        return authenticateWithApiKey(options);
+      }
+    }
+    throw err;
+  }
+}
+
+export async function authenticateWithProvider(
+  options: AuthenticateOptions,
+): Promise<AuthenticatedCredentials> {
+  const mode = await resolveAuthMode(options);
+  if (mode === "device_code") {
+    return authenticateWithDeviceCode(options);
+  }
+  return authenticateWithApiKey(options);
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,65 @@
+export const CREDENTIALS_VERSION = 2;
+export const LEGACY_CREDENTIALS_VERSION = 1;
+
+export type StoredCredentialKind = "api_key" | "device_code" | "sagemaker";
+
+export interface StoredApiKeyCredentials {
+  version: typeof CREDENTIALS_VERSION;
+  kind: "api_key";
+  api_key: string;
+}
+
+export interface StoredDeviceCodeCredentials {
+  version: typeof CREDENTIALS_VERSION;
+  kind: "device_code";
+  access_token: string;
+  refresh_token?: string;
+  expires_at?: string;
+  token_type?: string;
+  scope?: string;
+}
+
+/** Self-hosted SageMaker embedding endpoint — mutually exclusive with Takara token auth. */
+export interface StoredSageMakerCredentials {
+  version: typeof CREDENTIALS_VERSION;
+  kind: "sagemaker";
+  endpoint_arn: string;
+  profile?: string;
+}
+
+export type StoredCredentials =
+  | StoredApiKeyCredentials
+  | StoredDeviceCodeCredentials
+  | StoredSageMakerCredentials;
+
+/** Pre-v2 credentials.json shape, from before device-code auth and the `kind` discriminator existed. */
+export interface LegacyStoredCredentials {
+  version: typeof LEGACY_CREDENTIALS_VERSION;
+  takara_api_key?: string;
+  sagemaker?: { endpoint_arn: string; profile?: string };
+}
+
+export type SaveStoredCredentialsInput =
+  | string
+  | { kind: "api_key"; apiKey: string }
+  | {
+      kind: "device_code";
+      accessToken: string;
+      refreshToken?: string;
+      expiresAt?: string;
+      tokenType?: string;
+      scope?: string;
+    }
+  | { kind: "sagemaker"; endpointArn: string; profile?: string };
+
+export type AuthenticatedCredentials = Exclude<
+  SaveStoredCredentialsInput,
+  string | { kind: "sagemaker"; endpointArn: string; profile?: string }
+>;
+
+/** Token to hydrate TAKARA_API_KEY with. Not defined for SageMaker (AWS-profile auth, no bearer token). */
+export function credentialAccessToken(
+  credentials: StoredApiKeyCredentials | StoredDeviceCodeCredentials,
+): string {
+  return credentials.kind === "api_key" ? credentials.api_key : credentials.access_token;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -685,7 +685,11 @@ async function runMcp(argv: string[]): Promise<void> {
 }
 
 async function runMcpWithCredentials(argv: string[]): Promise<void> {
-  await ensureCredentials({ interactive: true });
+  // The MCP server is spawned as a headless stdio subprocess, never a real
+  // login terminal — force the non-interactive path so a cold start with no
+  // cached credentials fails fast with an actionable error instead of
+  // attempting a doomed inline device-code login.
+  await ensureCredentials({ interactive: false });
   await runMcp(argv);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,13 @@ process.title = "miru";
 
 await loadEnvFiles();
 normalizeTakaraApiKeyEnv();
-await loadStoredCredentials();
+// Soft-fail: expired/revoked device refresh must not brick `miru -v`, `setup --clear`, etc.
+// Command paths call ensureCredentials() which recovers interactively when allowed.
+try {
+  await loadStoredCredentials();
+} catch {
+  // Leave recovery to ensureCredentials / setup.
+}
 
 const CLI_COMMANDS = new Set([
   "search",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -474,11 +474,19 @@ async function runCli(argv: string[]): Promise<void> {
   if (command === "setup") {
     const { args, error } = parseSetupCliArgs(rest);
     if (error === "clear_with_key") {
-      fail("miru setup --clear cannot be combined with --key.");
+      fail("miru setup --clear cannot be combined with --key, --device, or --sagemaker.");
       process.exit(1);
     }
     if (error === "sagemaker_with_key") {
       fail("miru setup --sagemaker cannot be combined with --key.");
+      process.exit(1);
+    }
+    if (error === "device_with_key") {
+      fail("miru setup accepts either --device or --key TOKEN, not both.");
+      process.exit(1);
+    }
+    if (error === "device_with_sagemaker") {
+      fail("miru setup --device cannot be combined with --sagemaker.");
       process.exit(1);
     }
     if (args.clear) {
@@ -487,13 +495,15 @@ async function runCli(argv: string[]): Promise<void> {
     }
     const { newlySaved } = await runSetup({
       apiKey: args.apiKey,
+      device: args.device,
       force: args.force,
       sagemaker: args.sagemaker,
       sagemakerArn: args.sagemakerArn,
       profile: args.profile,
     });
     if (newlySaved) {
-      const offerInstall = canPromptForCredentials() && !args.apiKey && !args.force;
+      const offerInstall =
+        canPromptForCredentials() && !args.apiKey && !args.device && !args.force;
       if (offerInstall) {
         const install = await promptConfirm("Configure Miru in your coding agent now?");
         if (install) {
@@ -675,7 +685,7 @@ async function runMcp(argv: string[]): Promise<void> {
 }
 
 async function runMcpWithCredentials(argv: string[]): Promise<void> {
-  await ensureCredentials({ interactive: false });
+  await ensureCredentials({ interactive: true });
   await runMcp(argv);
 }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,19 +1,26 @@
-import { chmod, mkdir } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { hasTakaraApiKeyInEnv, normalizeTakaraApiKeyEnv } from "./env.ts";
+import {
+  deviceCredentialsNeedRefresh,
+  refreshDeviceAuthorization,
+} from "./auth/device.ts";
+import {
+  CREDENTIALS_VERSION,
+  LEGACY_CREDENTIALS_VERSION,
+  type LegacyStoredCredentials,
+  type SaveStoredCredentialsInput,
+  type StoredCredentials,
+  type StoredSageMakerCredentials,
+  credentialAccessToken,
+} from "./auth/types.ts";
 
 const CREDENTIALS_FILENAME = "credentials.json";
-const CREDENTIALS_VERSION = 1;
+let activeStoredToken: string | null = null;
 
-export interface StoredSageMakerCredentials {
-  endpoint_arn: string;
-  profile?: string;
-}
-
-interface StoredCredentials {
-  version: number;
-  takara_api_key?: string;
-  sagemaker?: StoredSageMakerCredentials;
+export function setStoredCredentialsEnvToken(token: string): void {
+  activeStoredToken = token;
+  process.env.TAKARA_API_KEY = token;
 }
 
 export function resolveCredentialsDir(): string {
@@ -51,11 +58,44 @@ export async function readStoredCredentials(): Promise<StoredCredentials | null>
     return null;
   }
   try {
-    const parsed = JSON.parse(await Bun.file(path).text()) as StoredCredentials;
-    if (parsed.version !== CREDENTIALS_VERSION || (!parsed.takara_api_key && !parsed.sagemaker)) {
+    const parsed = JSON.parse(await readFile(path, "utf-8")) as
+      | StoredCredentials
+      | LegacyStoredCredentials;
+    if (parsed.version === LEGACY_CREDENTIALS_VERSION) {
+      if (parsed.sagemaker) {
+        return {
+          version: CREDENTIALS_VERSION,
+          kind: "sagemaker",
+          endpoint_arn: parsed.sagemaker.endpoint_arn,
+          profile: parsed.sagemaker.profile,
+        };
+      }
+      if (parsed.takara_api_key?.trim()) {
+        return {
+          version: CREDENTIALS_VERSION,
+          kind: "api_key",
+          api_key: parsed.takara_api_key,
+        };
+      }
       return null;
     }
-    return parsed;
+    if (parsed.version !== CREDENTIALS_VERSION || !("kind" in parsed)) {
+      return null;
+    }
+    if (parsed.kind === "api_key" && parsed.api_key?.trim()) {
+      return parsed;
+    }
+    if (parsed.kind === "sagemaker" && parsed.endpoint_arn?.trim()) {
+      return parsed;
+    }
+    if (parsed.kind === "device_code") {
+      if (!parsed.access_token?.trim()) {
+        // Treat incomplete device files as absent so `setup --clear` and recovery can proceed.
+        return null;
+      }
+      return parsed;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -85,26 +125,21 @@ function hydrateSageMakerEnv(sagemaker: StoredSageMakerCredentials): void {
 export async function beginModeSwitch(to: "takara" | "sagemaker"): Promise<void> {
   const stored = await readStoredCredentials();
   if (to === "takara") {
-    clearSageMakerEnv(stored?.sagemaker);
+    clearSageMakerEnv(stored?.kind === "sagemaker" ? stored : undefined);
   } else {
     clearTakaraEnv();
   }
 }
 
-async function writeExclusive(payload: StoredCredentials): Promise<string> {
-  const dir = resolveCredentialsDir();
-  const path = resolveCredentialsPath();
-  await mkdir(dir, { recursive: true, mode: 0o700 });
-  await Bun.write(path, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
-  try {
-    await chmod(path, 0o600);
-  } catch {
-    // Windows may not support Unix mode bits on all filesystems.
-  }
-  return path;
+function envUsesStoredToken(): boolean {
+  return activeStoredToken !== null && process.env.TAKARA_API_KEY === activeStoredToken;
 }
 
-/** Apply credentials.json as the sole mode — never leave Takara and SageMaker both active. */
+function markLoadedToken(token: string): void {
+  setStoredCredentialsEnvToken(token);
+}
+
+/** Hydrate TAKARA_API_KEY / SageMaker env vars from the credentials file when env is unset. */
 export async function loadStoredCredentials(): Promise<boolean> {
   normalizeTakaraApiKeyEnv();
   const stored = await readStoredCredentials();
@@ -112,23 +147,10 @@ export async function loadStoredCredentials(): Promise<boolean> {
     return false;
   }
 
-  if (stored.takara_api_key) {
-    let changed = false;
-    if (!hasTakaraApiKeyInEnv()) {
-      process.env.TAKARA_API_KEY = stored.takara_api_key;
-      changed = true;
-    }
-    if (process.env.MIRU_SAGEMAKER_ENDPOINT_ARN || process.env.MIRU_SAGEMAKER_ENDPOINT_NAME) {
-      clearSageMakerEnv(stored.sagemaker);
-      changed = true;
-    }
-    return changed;
-  }
-
-  if (stored.sagemaker) {
+  if (stored.kind === "sagemaker") {
     let changed = false;
     if (!process.env.MIRU_SAGEMAKER_ENDPOINT_ARN?.trim()) {
-      hydrateSageMakerEnv(stored.sagemaker);
+      hydrateSageMakerEnv(stored);
       changed = true;
     }
     if (hasTakaraApiKeyInEnv()) {
@@ -137,26 +159,102 @@ export async function loadStoredCredentials(): Promise<boolean> {
     }
     return changed;
   }
-  return false;
-}
 
-export async function saveStoredCredentials(apiKey: string): Promise<string> {
-  const previous = await readStoredCredentials();
-  const path = await writeExclusive({ version: CREDENTIALS_VERSION, takara_api_key: apiKey });
-  process.env.TAKARA_API_KEY = apiKey;
-  clearSageMakerEnv(previous?.sagemaker);
-  return path;
-}
+  // Takara token modes (api_key / device_code) are mutually exclusive with SageMaker.
+  const needsSageMakerClear = Boolean(
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN || process.env.MIRU_SAGEMAKER_ENDPOINT_NAME,
+  );
+  const needsToken = !hasTakaraApiKeyInEnv() || envUsesStoredToken();
 
-export async function saveStoredSageMakerCredentials(
-  sagemaker: StoredSageMakerCredentials,
-): Promise<string> {
-  const path = await writeExclusive({ version: CREDENTIALS_VERSION, sagemaker });
-  clearTakaraEnv();
-  process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = sagemaker.endpoint_arn;
-  if (sagemaker.profile) {
-    process.env.AWS_PROFILE = sagemaker.profile;
+  if (!needsToken && !needsSageMakerClear) {
+    return false;
   }
+
+  if (needsSageMakerClear) {
+    clearSageMakerEnv();
+  }
+
+  if (!needsToken) {
+    return true;
+  }
+
+  if (stored.kind === "device_code" && deviceCredentialsNeedRefresh(stored)) {
+    const refreshed = await refreshDeviceAuthorization(stored);
+    await saveStoredCredentials({
+      kind: "device_code",
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      expiresAt: refreshed.expiresAt,
+      tokenType: refreshed.tokenType,
+      scope: refreshed.scope,
+    });
+    markLoadedToken(refreshed.accessToken);
+    return true;
+  }
+  markLoadedToken(credentialAccessToken(stored));
+  return true;
+}
+
+export async function saveStoredCredentials(input: SaveStoredCredentialsInput): Promise<string> {
+  const dir = resolveCredentialsDir();
+  const path = resolveCredentialsPath();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+
+  const payload: StoredCredentials =
+    typeof input === "string" || input.kind === "api_key"
+      ? {
+          version: CREDENTIALS_VERSION,
+          kind: "api_key",
+          api_key: typeof input === "string" ? input : input.apiKey,
+        }
+      : input.kind === "sagemaker"
+        ? {
+            version: CREDENTIALS_VERSION,
+            kind: "sagemaker",
+            endpoint_arn: input.endpointArn,
+            profile: input.profile,
+          }
+        : {
+            version: CREDENTIALS_VERSION,
+            kind: "device_code",
+            access_token: input.accessToken,
+            refresh_token: input.refreshToken,
+            expires_at: input.expiresAt,
+            token_type: input.tokenType,
+            scope: input.scope,
+          };
+
+  await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  try {
+    await chmod(path, 0o600);
+  } catch {
+    // Windows may not support Unix mode bits on all filesystems.
+  }
+
+  // Takara-token and SageMaker modes are mutually exclusive — activating one mode
+  // unconditionally drops the other's env state, regardless of its current value.
+  if (payload.kind === "sagemaker") {
+    clearTakaraEnv();
+    activeStoredToken = null;
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = payload.endpoint_arn;
+    if (payload.profile) {
+      process.env.AWS_PROFILE = payload.profile;
+    }
+  } else {
+    delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    delete process.env.MIRU_SAGEMAKER_ENDPOINT_NAME;
+    delete process.env.MIRU_SAGEMAKER_REGION;
+    delete process.env.AWS_PROFILE;
+    // api_key saves activate immediately; device_code saves (initial login or refresh)
+    // leave env hydration to the caller (setup.ts / loadStoredCredentials refresh path).
+    if (payload.kind === "api_key") {
+      setStoredCredentialsEnvToken(payload.api_key);
+    }
+  }
+
   return path;
 }
 
@@ -166,15 +264,28 @@ export async function clearStoredCredentials(): Promise<{ cleared: boolean; path
     return { cleared: false, path };
   }
 
-  const stored = await readStoredCredentials();
-  await Bun.file(path).delete();
+  // Read for env cleanup, but never let parse errors block deletion.
+  let stored: StoredCredentials | null = null;
+  try {
+    stored = await readStoredCredentials();
+  } catch {
+    // Ignore parse/read errors — removal still proceeds.
+  }
+  await rm(path, { force: true });
 
-  if (stored?.takara_api_key && process.env.TAKARA_API_KEY === stored.takara_api_key) {
-    clearTakaraEnv();
+  if (stored) {
+    if (stored.kind === "sagemaker") {
+      if (process.env.MIRU_SAGEMAKER_ENDPOINT_ARN === stored.endpoint_arn) {
+        delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+      }
+      if (stored.profile && process.env.AWS_PROFILE === stored.profile) {
+        delete process.env.AWS_PROFILE;
+      }
+    } else if (process.env.TAKARA_API_KEY === credentialAccessToken(stored)) {
+      delete process.env.TAKARA_API_KEY;
+    }
   }
-  if (stored?.sagemaker) {
-    clearSageMakerEnv(stored.sagemaker);
-  }
+  activeStoredToken = null;
 
   return { cleared: true, path };
 }

--- a/src/embeddings/openai.ts
+++ b/src/embeddings/openai.ts
@@ -1,4 +1,5 @@
 import { mapPool, resolveWorkerConcurrency } from "../concurrency.ts";
+import { loadStoredCredentials } from "../credentials.ts";
 import { envFirstString, envOptionalInt, resolveEmbeddingApiKey } from "../env.ts";
 import { createSageMakerClient, resolveSageMakerConfig } from "./sagemaker.ts";
 
@@ -346,8 +347,6 @@ class EmbeddingApiError extends Error {
 }
 
 function createClient(): EmbeddingClient {
-  const apiKey = resolveEmbeddingApiKey();
-
   const baseUrl = resolveEmbeddingBaseUrl();
   const endpoint = `${baseUrl}/embeddings`;
 
@@ -357,6 +356,8 @@ function createClient(): EmbeddingClient {
       model: string,
       dimensions?: number,
     ): Promise<EmbeddingResponse> {
+      await loadStoredCredentials();
+      const apiKey = resolveEmbeddingApiKey();
       const body: Record<string, unknown> = { model, input };
       if (dimensions != null) {
         body.dimensions = dimensions;

--- a/src/env.ts
+++ b/src/env.ts
@@ -60,7 +60,7 @@ export function resolveEmbeddingApiKey(): string {
   const key = process.env[TAKARA_API_KEY_ENV]?.trim() ?? "";
   if (!isUsableTakaraApiKey(key)) {
     throw new Error(
-      "Takara API key required. Run `miru setup`, or set TAKARA_API_KEY in your MCP server env or .env.local.",
+      "Takara credentials required. Run `miru setup`, or set TAKARA_API_KEY in your MCP server env or .env.local.",
     );
   }
   return key;

--- a/src/help.ts
+++ b/src/help.ts
@@ -37,7 +37,7 @@ export function printMainHelp(): void {
   commandRow("locate", "Exact substring location in the index");
   commandRow("expand", "Adjacent chunks in the same file as a hit");
   commandRow("find-related", "Find chunks related to a file:line");
-  commandRow("setup", "Save your Takara API key locally");
+  commandRow("setup", "Authenticate with Takara and save local credentials");
   commandRow("install", "Configure miru across coding agents");
   commandRow("uninstall", "Remove miru agent configuration");
   commandRow("benchmark", "Turn MCP benchmark mode on or off");
@@ -147,13 +147,14 @@ export function printCommandHelp(command: string): void {
       writeStdout("");
       return;
     case "setup":
-      commandHeader("setup", "Store and validate Takara or self-hosted SageMaker credentials.");
+      commandHeader("setup", "Authenticate with Takara or self-hosted SageMaker credentials.");
       section("Usage");
-      writeStdout("  miru setup [--key TOKEN] [--force] [--clear]");
+      writeStdout("  miru setup [--device] [--key TOKEN] [--force] [--clear]");
       writeStdout("  miru setup --sagemaker --arn ENDPOINT_ARN --profile NAME");
       section("Options (Takara)");
-      writeStdout("  --key, -k TOKEN     Non-interactive key entry");
-      writeStdout("  --force             Replace an existing stored key");
+      writeStdout("  --device            Start device-code login (default when interactive)");
+      writeStdout("  --key, -k TOKEN     Non-interactive: store a bearer token directly");
+      writeStdout("  --force             Replace existing stored credentials");
       writeStdout("  --clear             Remove stored credentials");
       section("Options (SageMaker)");
       writeStdout("  --sagemaker         Switch setup to self-hosted SageMaker mode");

--- a/src/installer/search-policy.ts
+++ b/src/installer/search-policy.ts
@@ -88,7 +88,7 @@ export const INSTRUCTIONS_MARKDOWN = `## Miru Code Search
 
 ${SEARCH_POLICY_BODY}
 
-Run \`miru setup\` once — the MCP server loads your API key from \`credentials.json\`.
+Run \`miru setup\` once — the MCP server loads credentials from \`credentials.json\`, and interactive first use can auto-start device login when nothing is stored.
 
 CLI fallback when MCP is unavailable:
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -73,7 +73,10 @@ export async function promptText(message: string, defaultValue = ""): Promise<st
   }
 }
 
-export async function promptHidden(message: string): Promise<string> {
+export async function promptHidden(
+  message: string,
+  stream: NodeJS.WriteStream = output,
+): Promise<string> {
   if (!input.isTTY) {
     throw new Error(
       "Cannot prompt for API key: stdin is not a TTY. Run `miru setup --key YOUR_KEY` or set TAKARA_API_KEY.",
@@ -81,7 +84,7 @@ export async function promptHidden(message: string): Promise<string> {
   }
 
   return new Promise((resolve, reject) => {
-    output.write(message);
+    stream.write(message);
     input.setRawMode?.(true);
     input.resume();
     input.setEncoding("utf8");
@@ -95,20 +98,20 @@ export async function promptHidden(message: string): Promise<string> {
 
         if (result.cancel) {
           cleanup();
-          output.write("\n");
+          stream.write("\n");
           reject(new Error("Setup cancelled."));
           process.exit(130);
         }
 
         if (result.submit) {
           cleanup();
-          output.write("\n");
+          stream.write("\n");
           resolve(state.value.trim());
           return;
         }
 
         if (result.echo) {
-          output.write(result.echo);
+          stream.write(result.echo);
         }
       }
     };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,3 +1,5 @@
+import { authenticateWithProvider } from "./auth/providers.ts";
+import { credentialAccessToken } from "./auth/types.ts";
 import { divider, fail, hint, info, printBrandBanner, success, writeStdout } from "./cli-ui.ts";
 import {
   beginModeSwitch,
@@ -5,9 +7,8 @@ import {
   loadStoredCredentials,
   readStoredCredentials,
   resolveCredentialsPath,
-  type StoredSageMakerCredentials,
   saveStoredCredentials,
-  saveStoredSageMakerCredentials,
+  setStoredCredentialsEnvToken,
 } from "./credentials.ts";
 import {
   isSageMakerConfigured,
@@ -15,29 +16,20 @@ import {
   type SageMakerEmbeddingConfig,
   validateSageMakerConnection,
 } from "./embeddings/sagemaker.ts";
-import { validateEmbeddingApiKey } from "./embeddings/validate.ts";
 import { hasTakaraApiKeyInEnv, resolveEmbeddingApiKey } from "./env.ts";
-import { promptHidden, promptText } from "./prompt.ts";
+import { promptText } from "./prompt.ts";
 import { Spinner } from "./spinner.ts";
-
-async function promptApiKey(): Promise<string> {
-  let key = "";
-  while (!key) {
-    key = await promptHidden("Takara API key (input hidden): ");
-    if (!key) {
-      fail("API key cannot be empty.");
-    }
-  }
-  return key;
-}
 
 export interface RunSetupOptions {
   apiKey?: string;
+  device?: boolean;
   force?: boolean;
   skipValidation?: boolean;
   sagemaker?: boolean;
   sagemakerArn?: string;
   profile?: string;
+  allowManualFallback?: boolean;
+  interactive?: boolean;
 }
 
 export interface RunSetupResult {
@@ -47,6 +39,7 @@ export interface RunSetupResult {
 
 export interface ParsedSetupCliArgs {
   apiKey?: string;
+  device: boolean;
   force: boolean;
   clear: boolean;
   sagemaker: boolean;
@@ -54,7 +47,11 @@ export interface ParsedSetupCliArgs {
   profile?: string;
 }
 
-export type SetupCliArgError = "clear_with_key" | "sagemaker_with_key";
+export type SetupCliArgError =
+  | "clear_with_key"
+  | "sagemaker_with_key"
+  | "device_with_key"
+  | "device_with_sagemaker";
 
 /** Parse `miru setup` argv (everything after the `setup` command). */
 export function parseSetupCliArgs(rest: string[]): {
@@ -62,6 +59,7 @@ export function parseSetupCliArgs(rest: string[]): {
   error?: SetupCliArgError;
 } {
   let apiKey: string | undefined;
+  let device = false;
   let force = false;
   let clear = false;
   let sagemaker = false;
@@ -74,6 +72,8 @@ export function parseSetupCliArgs(rest: string[]): {
       force = true;
     } else if (arg === "--clear") {
       clear = true;
+    } else if (arg === "--device") {
+      device = true;
     } else if ((arg === "--key" || arg === "-k") && rest[i + 1]) {
       apiKey = rest[++i];
     } else if (arg === "--sagemaker") {
@@ -91,6 +91,7 @@ export function parseSetupCliArgs(rest: string[]): {
 
   const args: ParsedSetupCliArgs = {
     apiKey,
+    device,
     force,
     clear,
     sagemaker,
@@ -98,11 +99,17 @@ export function parseSetupCliArgs(rest: string[]): {
     profile,
   };
 
-  if (clear && apiKey) {
+  if (clear && (apiKey || device || sagemaker)) {
     return { args, error: "clear_with_key" };
   }
   if (sagemaker && apiKey) {
     return { args, error: "sagemaker_with_key" };
+  }
+  if (device && apiKey) {
+    return { args, error: "device_with_key" };
+  }
+  if (device && sagemaker) {
+    return { args, error: "device_with_sagemaker" };
   }
   return { args };
 }
@@ -147,7 +154,7 @@ export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<
   writeStdout("Miru will connect directly to your self-hosted SageMaker embedding endpoint.");
   hint("Miru only inherits AWS credentials from a profile you've already configured —");
   hint("it never creates or writes to ~/.aws. Run `aws configure --profile <name>` first.");
-  hint("This replaces any stored Takara API key — only one embedding mode is active at a time.");
+  hint("This replaces any stored Takara credentials — only one embedding mode is active at a time.");
   writeStdout("");
 
   const arnInput = options.sagemakerArn ?? (await promptSageMakerArn());
@@ -186,13 +193,12 @@ export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<
     spinner.succeed("SageMaker endpoint validated");
   }
 
-  const stored: StoredSageMakerCredentials = { endpoint_arn: arnInput, profile };
-  const hadTakaraKey = Boolean((await readStoredCredentials())?.takara_api_key);
-  const path = await saveStoredSageMakerCredentials(stored);
+  const hadStoredCredentials = Boolean(await readStoredCredentials());
+  const path = await saveStoredCredentials({ kind: "sagemaker", endpointArn: arnInput, profile });
   writeStdout("");
   success(`Saved SageMaker config to ${path}`);
-  if (hadTakaraKey) {
-    hint("Removed the stored Takara API key — Miru now embeds only via SageMaker.");
+  if (hadStoredCredentials) {
+    hint("Removed the stored Takara credentials — Miru now embeds only via SageMaker.");
   } else {
     hint("Miru will embed via this SageMaker endpoint (Takara is not used).");
   }
@@ -205,10 +211,11 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
     return runSageMakerSetup(options);
   }
 
-  if (!options.force && hasTakaraApiKeyInEnv()) {
+  const interactive = options.interactive ?? canPromptForCredentials();
+  if (!options.force && hasTakaraApiKeyInEnv() && !options.apiKey && !options.device) {
     const path = resolveCredentialsPath();
     const stored = await readStoredCredentials();
-    if (stored?.sagemaker) {
+    if (stored?.kind === "sagemaker") {
       const saved = await saveStoredCredentials(resolveEmbeddingApiKey());
       writeStdout("");
       success(`Saved credentials to ${saved}`);
@@ -216,8 +223,8 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
       writeStdout("");
       return { path: saved, newlySaved: true };
     }
-    if (stored?.takara_api_key) {
-      info(`API key already configured (env + ${path}). Use --force to replace stored key.`);
+    if (stored) {
+      info(`Credentials already configured (env + ${path}). Use --force to replace stored credentials.`);
       return { path, newlySaved: false };
     }
     info("API key already set via environment variable. Stored credentials unchanged.");
@@ -226,9 +233,9 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
 
   if (!options.force) {
     const stored = await readStoredCredentials();
-    if (stored?.takara_api_key && !options.apiKey) {
-      info(`API key already stored at ${resolveCredentialsPath()}. Use --force to replace.`);
-      process.env.TAKARA_API_KEY = stored.takara_api_key;
+    if (stored && stored.kind !== "sagemaker" && !options.apiKey && !options.device) {
+      info(`Credentials already stored at ${resolveCredentialsPath()}. Use --force to replace.`);
+      setStoredCredentialsEnvToken(credentialAccessToken(stored));
       return { path: resolveCredentialsPath(), newlySaved: false };
     }
   }
@@ -237,29 +244,25 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
   // stderr banner: setup runs before stdout may be a TTY (e.g. piped miru search).
   printBrandBanner(process.stderr);
   divider("─", 48, process.stderr);
-  writeStdout("Miru needs a Takara API key for code embeddings.");
-  hint("Get a bearer token from Takara, then enter it below.");
-  hint(
-    "This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.",
-  );
+  writeStdout("Miru needs Takara credentials for code embeddings.");
+  hint("Device code login is the default. Manual API key entry is still available.");
+  hint("This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.");
   writeStdout("");
 
-  const apiKey = options.apiKey ?? (await promptApiKey());
-
   await beginModeSwitch("takara");
-  if (!options.skipValidation) {
-    const spinner = new Spinner("Validating API key");
-    spinner.start();
-    const result = await validateEmbeddingApiKey({ apiKey });
-    if (!result.valid) {
-      spinner.stop();
-      throw new Error(result.message);
-    }
-    spinner.succeed("API key validated");
-  }
 
-  const hadSageMaker = Boolean((await readStoredCredentials())?.sagemaker);
-  const path = await saveStoredCredentials(apiKey);
+  const hadSageMaker = (await readStoredCredentials())?.kind === "sagemaker";
+  const credentials = await authenticateWithProvider({
+    apiKey: options.apiKey,
+    device: options.device,
+    skipValidation: options.skipValidation,
+    allowManualFallback: options.allowManualFallback ?? interactive,
+    interactive,
+  });
+  const path = await saveStoredCredentials(credentials);
+  setStoredCredentialsEnvToken(
+    credentials.kind === "api_key" ? credentials.apiKey : credentials.accessToken,
+  );
   writeStdout("");
   success(`Saved credentials to ${path}`);
   if (hadSageMaker) {
@@ -305,19 +308,38 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
     return;
   }
 
-  await refreshCredentialsFromStore();
+  const wantsPrompt = options?.interactive ?? true;
+  let refreshError: Error | null = null;
+  try {
+    await refreshCredentialsFromStore();
+  } catch (err) {
+    refreshError = err instanceof Error ? err : new Error(String(err));
+  }
   if (hasCredentials()) {
     return;
   }
 
-  const wantsPrompt = options?.interactive ?? true;
-  if (wantsPrompt && canPromptForCredentials()) {
+  if (wantsPrompt) {
     writeStdout("");
-    info("No Takara API key found.");
-    hint("Miru needs one for embeddings — enter it below (same as `miru setup`).");
-    await runSetup();
+    if (refreshError) {
+      info(`Stored credentials could not be used: ${refreshError.message}`);
+      hint("Starting a fresh device-code login.");
+    } else {
+      info("No Takara credentials found.");
+      hint("Starting the same device-code login flow as `miru setup`.");
+    }
+    await runSetup({
+      device: true,
+      force: true,
+      allowManualFallback: false,
+      interactive: true,
+    });
     resolveEmbeddingApiKey();
     return;
+  }
+
+  if (refreshError) {
+    throw refreshError;
   }
 
   writeStdout("");
@@ -326,7 +348,7 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
   writeStdout("");
 
   throw new Error(
-    "Takara API key required. Run `miru setup` in a terminal, or set TAKARA_API_KEY " +
-      "in your MCP server env (Cursor mcp.json) or .env.local.",
+    "Takara credentials required. Initial login must be completed in an interactive terminal. " +
+      "Run `miru setup` or `miru setup --key TOKEN`, or set TAKARA_API_KEY in your environment.",
   );
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,6 @@
 import { authenticateWithProvider } from "./auth/providers.ts";
 import { credentialAccessToken } from "./auth/types.ts";
-import { divider, fail, hint, info, printBrandBanner, success, writeStdout } from "./cli-ui.ts";
+import { divider, fail, hint, info, printBrandBanner, success, writeStderr, writeStdout } from "./cli-ui.ts";
 import {
   beginModeSwitch,
   clearStoredCredentials,
@@ -240,14 +240,14 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
     }
   }
 
-  writeStdout("");
-  // stderr banner: setup runs before stdout may be a TTY (e.g. piped miru search).
+  writeStderr("");
+  // stderr: setup/MCP must not write human auth UI to stdout (JSON-RPC / piped CLI).
   printBrandBanner(process.stderr);
   divider("─", 48, process.stderr);
-  writeStdout("Miru needs Takara credentials for code embeddings.");
+  writeStderr("Miru needs Takara credentials for code embeddings.");
   hint("Device code login is the default. Manual API key entry is still available.");
   hint("This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.");
-  writeStdout("");
+  writeStderr("");
 
   await beginModeSwitch("takara");
 
@@ -263,14 +263,14 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
   setStoredCredentialsEnvToken(
     credentials.kind === "api_key" ? credentials.apiKey : credentials.accessToken,
   );
-  writeStdout("");
+  writeStderr("");
   success(`Saved credentials to ${path}`);
   if (hadSageMaker) {
     hint("Removed the stored SageMaker endpoint — Miru now embeds only via Takara.");
   } else {
     hint("MCP loads this key from credentials.json automatically.");
   }
-  writeStdout("");
+  writeStderr("");
   return { path, newlySaved: true };
 }
 
@@ -320,7 +320,7 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
   }
 
   if (wantsPrompt) {
-    writeStdout("");
+    writeStderr("");
     if (refreshError) {
       info(`Stored credentials could not be used: ${refreshError.message}`);
       hint("Starting a fresh device-code login.");
@@ -342,10 +342,10 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
     throw refreshError;
   }
 
-  writeStdout("");
+  writeStderr("");
   // Brand on stderr when credentials are missing in non-interactive mode (stdout may not be a TTY).
   printBrandBanner(process.stderr);
-  writeStdout("");
+  writeStderr("");
 
   throw new Error(
     "Takara credentials required. Initial login must be completed in an interactive terminal. " +

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -233,6 +233,78 @@ describe("credentials", () => {
     expect(stored.refresh_token).toBe("fresh-refresh-token");
   });
 
+  test("loadStoredCredentials surfaces refresh failures for callers to recover", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    process.env.MIRU_AUTH_BASE_URL = "https://auth.example.test";
+    process.env.MIRU_AUTH_CLIENT_ID = "miru-test";
+    clearTakaraApiKey();
+    await saveStoredCredentials({
+      kind: "device_code",
+      accessToken: "expired-token",
+      refreshToken: "revoked-refresh",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    globalThis.fetch = (async (_input, _init) =>
+      new Response(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Refresh token revoked",
+        }),
+        { status: 400 },
+      )) as typeof fetch;
+
+    await expect(loadStoredCredentials()).rejects.toThrow(/Device token refresh failed/);
+    expect(process.env.TAKARA_API_KEY).toBeUndefined();
+  });
+
+  test("readStoredCredentials returns null for incomplete device credentials", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    const path = join(credDir, "credentials.json");
+    await Bun.write(
+      path,
+      JSON.stringify(
+        {
+          version: CREDENTIALS_VERSION,
+          kind: "device_code",
+          access_token: "",
+          refresh_token: "orphan-refresh",
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    await chmod(path, 0o600);
+    expect(await readStoredCredentials()).toBeNull();
+  });
+
+  test("clearStoredCredentials removes incomplete device credential files", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    clearTakaraApiKey();
+    const path = join(credDir, "credentials.json");
+    await Bun.write(
+      path,
+      JSON.stringify(
+        {
+          version: CREDENTIALS_VERSION,
+          kind: "device_code",
+          access_token: "   ",
+          refresh_token: "orphan-refresh",
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    await chmod(path, 0o600);
+
+    const result = await clearStoredCredentials();
+    expect(result.cleared).toBe(true);
+    expect(await Bun.file(path).exists()).toBe(false);
+  });
+
   test("clearStoredCredentials removes file and unsets loaded env", async () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmod, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CREDENTIALS_VERSION } from "../src/auth/types.ts";
 import {
   clearStoredCredentials,
   loadStoredCredentials,
@@ -9,7 +10,6 @@ import {
   resolveCredentialsDir,
   resolveMiruStateDir,
   saveStoredCredentials,
-  saveStoredSageMakerCredentials,
 } from "../src/credentials.ts";
 import { TAKARA_API_KEY_ENV } from "../src/env.ts";
 
@@ -40,11 +40,14 @@ describe("credentials", () => {
   let takaraApiKeySnapshot: string | undefined;
   let sageMakerArnSnapshot: string | undefined;
   let awsProfileSnapshot: string | undefined;
+  const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     takaraApiKeySnapshot = snapshotTakaraApiKey();
     sageMakerArnSnapshot = process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
     awsProfileSnapshot = process.env.AWS_PROFILE;
+    delete process.env.MIRU_AUTH_BASE_URL;
+    delete process.env.MIRU_AUTH_CLIENT_ID;
   });
 
   afterEach(async () => {
@@ -56,6 +59,7 @@ describe("credentials", () => {
     } else {
       process.env.MIRU_CREDENTIALS_DIR = prevDir;
     }
+    globalThis.fetch = originalFetch;
     restoreTakaraApiKey(takaraApiKeySnapshot);
     if (sageMakerArnSnapshot === undefined) {
       delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
@@ -77,10 +81,12 @@ describe("credentials", () => {
     const path = await saveStoredCredentials("secret-token");
     const raw = JSON.parse(await readFile(path, "utf-8")) as {
       version: number;
-      takara_api_key: string;
+      kind: string;
+      api_key: string;
     };
-    expect(raw.version).toBe(1);
-    expect(raw.takara_api_key).toBe("secret-token");
+    expect(raw.version).toBe(CREDENTIALS_VERSION);
+    expect(raw.kind).toBe("api_key");
+    expect(raw.api_key).toBe("secret-token");
 
     const fileStat = await stat(path);
     if (process.platform !== "win32") {
@@ -152,6 +158,81 @@ describe("credentials", () => {
     expect(await readStoredCredentials()).toBeNull();
   });
 
+  test("readStoredCredentials migrates legacy version-1 API-key files in memory", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    const path = join(credDir, "credentials.json");
+    await Bun.write(path, '{\n  "version": 1,\n  "takara_api_key": "legacy-token"\n}\n');
+    await chmod(path, 0o600);
+
+    await expect(readStoredCredentials()).resolves.toEqual({
+      version: CREDENTIALS_VERSION,
+      kind: "api_key",
+      api_key: "legacy-token",
+    });
+  });
+
+  test("readStoredCredentials migrates legacy version-1 SageMaker files in memory", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    const path = join(credDir, "credentials.json");
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    await Bun.write(
+      path,
+      `{\n  "version": 1,\n  "sagemaker": {"endpoint_arn": "${arn}", "profile": "miru"}\n}\n`,
+    );
+    await chmod(path, 0o600);
+
+    await expect(readStoredCredentials()).resolves.toEqual({
+      version: CREDENTIALS_VERSION,
+      kind: "sagemaker",
+      endpoint_arn: arn,
+      profile: "miru",
+    });
+  });
+
+  test("loadStoredCredentials refreshes expired device credentials", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    process.env.MIRU_AUTH_BASE_URL = "https://auth.example.test";
+    process.env.MIRU_AUTH_CLIENT_ID = "miru-test";
+    clearTakaraApiKey();
+    await saveStoredCredentials({
+      kind: "device_code",
+      accessToken: "expired-token",
+      refreshToken: "refresh-token",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    globalThis.fetch = (async (input, init) => {
+      expect(String(input)).toBe("https://auth.example.test/oauth/token");
+      expect(init?.method).toBe("POST");
+      expect(String(init?.body)).toContain("grant_type=refresh_token");
+      return new Response(
+        JSON.stringify({
+          access_token: "fresh-token",
+          refresh_token: "fresh-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const loaded = await loadStoredCredentials();
+    expect(loaded).toBe(true);
+    expect(process.env.TAKARA_API_KEY).toBe("fresh-token");
+
+    const stored = JSON.parse(await readFile(join(credDir, "credentials.json"), "utf-8")) as {
+      kind: string;
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(stored.kind).toBe("device_code");
+    expect(stored.access_token).toBe("fresh-token");
+    expect(stored.refresh_token).toBe("fresh-refresh-token");
+  });
+
   test("clearStoredCredentials removes file and unsets loaded env", async () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;
@@ -189,16 +270,29 @@ describe("credentials", () => {
 
     await saveStoredCredentials("takara-token");
     process.env.TAKARA_API_KEY = "env-only-token";
-    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
-    expect((await readStoredCredentials())?.takara_api_key).toBeUndefined();
+    await saveStoredCredentials({ kind: "sagemaker", endpointArn: arn, profile: "miru" });
+
+    const stored = await readStoredCredentials();
+    expect(stored?.kind).toBe("sagemaker");
+    expect(stored).toMatchObject({ kind: "sagemaker", endpoint_arn: arn, profile: "miru" });
     expect(process.env.TAKARA_API_KEY).toBeUndefined();
     expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBe(arn);
+  });
 
+  test("saving Takara credentials removes stored SageMaker endpoint", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    clearTakaraApiKey();
+    clearSageMakerEnv();
+
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    await saveStoredCredentials({ kind: "sagemaker", endpointArn: arn, profile: "miru" });
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = arn;
     process.env.AWS_PROFILE = "miru";
     await saveStoredCredentials("takara-token");
     const stored = await readStoredCredentials();
-    expect(stored?.sagemaker).toBeUndefined();
-    expect(stored?.takara_api_key).toBe("takara-token");
+    expect(stored?.kind).toBe("api_key");
+    expect(stored).toMatchObject({ kind: "api_key", api_key: "takara-token" });
     expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBeUndefined();
     expect(process.env.AWS_PROFILE).toBeUndefined();
     expect(process.env.TAKARA_API_KEY).toBe("takara-token");
@@ -211,7 +305,7 @@ describe("credentials", () => {
     clearSageMakerEnv();
 
     const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
-    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
+    await saveStoredCredentials({ kind: "sagemaker", endpointArn: arn, profile: "miru" });
     process.env.TAKARA_API_KEY = "stale-takara";
 
     expect(await loadStoredCredentials()).toBe(true);

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -29,7 +29,7 @@ describe("resolveEmbeddingApiKey", () => {
     const prev = process.env.TAKARA_API_KEY;
     try {
       delete process.env.TAKARA_API_KEY;
-      expect(() => resolveEmbeddingApiKey()).toThrow(/Takara API key required/);
+      expect(() => resolveEmbeddingApiKey()).toThrow(/Takara credentials required/);
     } finally {
       if (prev === undefined) {
         delete process.env.TAKARA_API_KEY;
@@ -45,7 +45,7 @@ describe("resolveEmbeddingApiKey", () => {
       process.env.TAKARA_API_KEY = "$" + "{TAKARA_API_KEY}";
       expect(isUsableTakaraApiKey(process.env.TAKARA_API_KEY)).toBe(false);
       expect(hasTakaraApiKeyInEnv()).toBe(false);
-      expect(() => resolveEmbeddingApiKey()).toThrow(/Takara API key required/);
+      expect(() => resolveEmbeddingApiKey()).toThrow(/Takara credentials required/);
       normalizeTakaraApiKeyEnv();
       expect(process.env.TAKARA_API_KEY).toBeUndefined();
     } finally {

--- a/tests/plugin-manifest.test.ts
+++ b/tests/plugin-manifest.test.ts
@@ -1,37 +1,91 @@
 import { expect, test } from "bun:test";
 
-test("repo-local Codex plugin files are wired to the published Miru package", async () => {
-  const plugin = JSON.parse(
+test("Codex, Claude, and Cursor plugin manifests point at the Miru MCP runtime", async () => {
+  const codexPlugin = JSON.parse(
     await Bun.file(new URL("../.codex-plugin/plugin.json", import.meta.url)).text(),
   ) as {
     name: string;
+    skills?: string;
+    mcpServers: string;
+    interface: { displayName: string };
+  };
+  const claudePlugin = JSON.parse(
+    await Bun.file(new URL("../.claude-plugin/plugin.json", import.meta.url)).text(),
+  ) as {
+    name: string;
+    skills: string[];
+  };
+  const cursorPlugin = JSON.parse(
+    await Bun.file(new URL("../plugin.json", import.meta.url)).text(),
+  ) as {
+    name: string;
+    skills: string;
+    rules: string;
     mcpServers: string;
   };
   const mcp = JSON.parse(await Bun.file(new URL("../.mcp.json", import.meta.url)).text()) as {
     mcpServers: Record<string, { type: string; command: string; args: string[] }>;
   };
-  const marketplace = JSON.parse(
-    await Bun.file(new URL("../.agents/plugins/marketplace.json", import.meta.url)).text(),
-  ) as {
-    plugins: Array<{
-      name: string;
-      source: { source: string; path: string };
-      policy: { installation: string; authentication: string };
-      category: string;
-    }>;
-  };
 
-  expect(plugin.name).toBe("miru-code");
-  expect(plugin.mcpServers).toBe("./.mcp.json");
+  expect(codexPlugin.name).toBe("miru");
+  expect(codexPlugin.skills).toBe("./skills/");
+  expect(codexPlugin.mcpServers).toBe("./.mcp.json");
+  expect(codexPlugin.interface.displayName).toBe("Miru Code Search");
+
+  expect(claudePlugin.name).toBe("miru");
+  expect(claudePlugin.skills).toEqual(["./skills/"]);
+
+  expect(cursorPlugin.name).toBe("miru");
+  expect(cursorPlugin.skills).toBe("./skills/");
+  expect(cursorPlugin.rules).toBe("./.cursor/rules/miru-code-search.mdc");
+  expect(cursorPlugin.mcpServers).toBe("./.mcp.json");
+
   expect(mcp.mcpServers.miru).toEqual({
     type: "stdio",
     command: "bunx",
     args: ["@takara-ai/miru-code"],
   });
-  expect(marketplace.plugins[0]).toEqual({
-    name: "miru-code",
-    source: { path: ".", source: "local" },
+});
+
+test("host marketplace manifests point at the Miru repo", async () => {
+  const codexMarketplace = JSON.parse(
+    await Bun.file(new URL("../.agents/plugins/marketplace.json", import.meta.url)).text(),
+  ) as {
+    plugins: Array<{
+      name: string;
+      source: { source: string; url: string; ref: string };
+      policy: { installation: string; authentication: string };
+      category: string;
+    }>;
+  };
+  const claudeMarketplace = JSON.parse(
+    await Bun.file(new URL("../.claude-plugin/marketplace.json", import.meta.url)).text(),
+  ) as {
+    name: string;
+    plugins: Array<{
+      name: string;
+      description: string;
+      source: string;
+      category: string;
+    }>;
+  };
+
+  expect(codexMarketplace.plugins[0]).toEqual({
+    name: "miru",
+    source: {
+      source: "url",
+      url: "https://github.com/takara-ai/miru-code.git",
+      ref: "main",
+    },
     policy: { installation: "AVAILABLE", authentication: "ON_USE" },
     category: "Productivity",
+  });
+
+  expect(claudeMarketplace.name).toBe("miru");
+  expect(claudeMarketplace.plugins[0]).toEqual({
+    name: "miru",
+    description: "Repo-aware semantic code search with MCP and first-use device authentication.",
+    source: "./",
+    category: "productivity",
   });
 });

--- a/tests/plugin-manifest.test.ts
+++ b/tests/plugin-manifest.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+
+test("repo-local Codex plugin files are wired to the published Miru package", async () => {
+  const plugin = JSON.parse(
+    await Bun.file(new URL("../.codex-plugin/plugin.json", import.meta.url)).text(),
+  ) as {
+    name: string;
+    mcpServers: string;
+  };
+  const mcp = JSON.parse(await Bun.file(new URL("../.mcp.json", import.meta.url)).text()) as {
+    mcpServers: Record<string, { type: string; command: string; args: string[] }>;
+  };
+  const marketplace = JSON.parse(
+    await Bun.file(new URL("../.agents/plugins/marketplace.json", import.meta.url)).text(),
+  ) as {
+    plugins: Array<{
+      name: string;
+      source: { source: string; path: string };
+      policy: { installation: string; authentication: string };
+      category: string;
+    }>;
+  };
+
+  expect(plugin.name).toBe("miru-code");
+  expect(plugin.mcpServers).toBe("./.mcp.json");
+  expect(mcp.mcpServers.miru).toEqual({
+    type: "stdio",
+    command: "bunx",
+    args: ["@takara-ai/miru-code"],
+  });
+  expect(marketplace.plugins[0]).toEqual({
+    name: "miru-code",
+    source: { path: ".", source: "local" },
+    policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+    category: "Productivity",
+  });
+});

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1,12 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  readStoredCredentials,
-  saveStoredCredentials,
-  saveStoredSageMakerCredentials,
-} from "../src/credentials.ts";
+import { loadStoredCredentials, readStoredCredentials, saveStoredCredentials } from "../src/credentials.ts";
 import { TAKARA_API_KEY_ENV } from "../src/env.ts";
 import {
   canPromptForCredentials,
@@ -34,6 +30,7 @@ describe("setup credentials", () => {
   let keySnapshot: string | undefined;
   let sageMakerArnSnapshot: string | undefined;
   let awsProfileSnapshot: string | undefined;
+  const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     keySnapshot = snapshotKey();
@@ -42,6 +39,8 @@ describe("setup credentials", () => {
     delete process.env[TAKARA_API_KEY_ENV];
     delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
     delete process.env.AWS_PROFILE;
+    delete process.env.MIRU_AUTH_BASE_URL;
+    delete process.env.MIRU_AUTH_CLIENT_ID;
   });
 
   afterEach(async () => {
@@ -56,6 +55,7 @@ describe("setup credentials", () => {
     } else {
       process.env.AWS_PROFILE = awsProfileSnapshot;
     }
+    globalThis.fetch = originalFetch;
     if (credDir) {
       await rm(credDir, { recursive: true, force: true });
       credDir = "";
@@ -72,13 +72,18 @@ describe("setup credentials", () => {
     expect(hasCredentials()).toBe(true);
   });
 
+  test("hasCredentials is true when SageMaker endpoint ARN is configured", () => {
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN =
+      "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    expect(hasCredentials()).toBe(true);
+  });
+
   test("hasCredentials is true after loadStoredCredentials", async () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-setup-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;
     await saveStoredCredentials("stored-token");
     delete process.env.TAKARA_API_KEY;
 
-    const { loadStoredCredentials } = await import("../src/credentials.ts");
     await loadStoredCredentials();
     expect(hasCredentials()).toBe(true);
   });
@@ -99,7 +104,7 @@ describe("setup credentials", () => {
     delete process.env.TAKARA_API_KEY;
 
     await expect(ensureCredentials({ interactive: false })).rejects.toThrow(
-      /Takara API key required/,
+      /Initial login must be completed in an interactive terminal/,
     );
   });
 
@@ -117,6 +122,15 @@ describe("setup credentials", () => {
     expect(result.path).toContain("credentials.json");
   });
 
+  test("runSetup accepts explicit key entry with validation disabled", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-explicit-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+
+    const result = await runSetup({ apiKey: "explicit-token", skipValidation: true, force: true });
+    expect(result.newlySaved).toBe(true);
+    expect(process.env.TAKARA_API_KEY).toBe("explicit-token");
+  });
+
   test("runSageMakerSetup purges a stored Takara API key", async () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-setup-sm-purge-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;
@@ -132,8 +146,8 @@ describe("setup credentials", () => {
 
     expect(result.newlySaved).toBe(true);
     const stored = await readStoredCredentials();
-    expect(stored?.takara_api_key).toBeUndefined();
-    expect(stored?.sagemaker).toEqual({ endpoint_arn: arn, profile: "miru" });
+    expect(stored?.kind).toBe("sagemaker");
+    expect(stored).toMatchObject({ kind: "sagemaker", endpoint_arn: arn, profile: "miru" });
     expect(process.env.TAKARA_API_KEY).toBeUndefined();
     // Cast: delete/assign on process.env narrows the property under Bun's Env types.
     expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN as string | undefined).toBe(arn);
@@ -143,7 +157,7 @@ describe("setup credentials", () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-setup-tk-purge-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;
     const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
-    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
+    await saveStoredCredentials({ kind: "sagemaker", endpointArn: arn, profile: "miru" });
     process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = arn;
     process.env.AWS_PROFILE = "miru";
     delete process.env.TAKARA_API_KEY;
@@ -156,8 +170,8 @@ describe("setup credentials", () => {
 
     expect(result.newlySaved).toBe(true);
     const stored = await readStoredCredentials();
-    expect(stored?.sagemaker).toBeUndefined();
-    expect(stored?.takara_api_key).toBe("new-takara-token");
+    expect(stored?.kind).toBe("api_key");
+    expect(stored).toMatchObject({ kind: "api_key", api_key: "new-takara-token" });
     expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBeUndefined();
     expect(process.env.AWS_PROFILE).toBeUndefined();
   });
@@ -166,7 +180,7 @@ describe("setup credentials", () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-setup-migrate-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;
     const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
-    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
+    await saveStoredCredentials({ kind: "sagemaker", endpointArn: arn, profile: "miru" });
     process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = arn;
     process.env.AWS_PROFILE = "miru";
     process.env.TAKARA_API_KEY = "env-takara-token";
@@ -175,8 +189,8 @@ describe("setup credentials", () => {
 
     expect(result.newlySaved).toBe(true);
     const stored = await readStoredCredentials();
-    expect(stored?.sagemaker).toBeUndefined();
-    expect(stored?.takara_api_key).toBe("env-takara-token");
+    expect(stored?.kind).toBe("api_key");
+    expect(stored).toMatchObject({ kind: "api_key", api_key: "env-takara-token" });
     expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBeUndefined();
     expect(process.env.AWS_PROFILE).toBeUndefined();
   });
@@ -187,12 +201,174 @@ describe("setup credentials", () => {
     expect(hasCredentials()).toBe(true);
     delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
   });
+
+  test("ensureCredentials can bootstrap device login without a TTY-style prompt path", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-device-bootstrap-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    process.env.MIRU_AUTH_BASE_URL = "https://auth.example.test";
+    process.env.MIRU_AUTH_CLIENT_ID = "miru-test";
+
+    let call = 0;
+    globalThis.fetch = (async (input) => {
+      call++;
+      if (call === 1) {
+        expect(String(input)).toBe("https://auth.example.test/oauth/device/code");
+        return new Response(
+          JSON.stringify({
+            device_code: "device-code",
+            user_code: "ABCD-EFGH",
+            verification_uri: "https://verify.example.test",
+            expires_in: 600,
+            interval: 0,
+          }),
+          { status: 200 },
+        );
+      }
+      expect(String(input)).toBe("https://auth.example.test/oauth/token");
+      return new Response(
+        JSON.stringify({
+          access_token: "device-access-token",
+          refresh_token: "device-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await ensureCredentials({ interactive: true });
+    expect(process.env.TAKARA_API_KEY).toBe("device-access-token");
+  });
+
+  test("ensureCredentials falls back to re-auth when refresh fails and interactive login is allowed", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-refresh-fallback-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    process.env.MIRU_AUTH_BASE_URL = "https://auth.example.test";
+    process.env.MIRU_AUTH_CLIENT_ID = "miru-test";
+    await saveStoredCredentials({
+      kind: "device_code",
+      accessToken: "stale-token",
+      refreshToken: "revoked-refresh-token",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    let call = 0;
+    globalThis.fetch = (async (input, init) => {
+      call++;
+      if (call === 1) {
+        expect(String(input)).toBe("https://auth.example.test/oauth/token");
+        expect(String(init?.body)).toContain("grant_type=refresh_token");
+        return new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description: "refresh token revoked",
+          }),
+          { status: 400 },
+        );
+      }
+      if (call === 2) {
+        expect(String(input)).toBe("https://auth.example.test/oauth/device/code");
+        return new Response(
+          JSON.stringify({
+            device_code: "new-device-code",
+            user_code: "ZXCV-BNMQ",
+            verification_uri: "https://verify.example.test",
+            expires_in: 600,
+            interval: 0,
+          }),
+          { status: 200 },
+        );
+      }
+      expect(String(input)).toBe("https://auth.example.test/oauth/token");
+      expect(String(init?.body)).toContain("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code");
+      return new Response(
+        JSON.stringify({
+          access_token: "reauth-token",
+          refresh_token: "reauth-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await ensureCredentials({ interactive: true });
+    expect(process.env.TAKARA_API_KEY).toBe("reauth-token");
+  });
+
+  test("runSetup marks saved device tokens as store-managed for later refresh in long-lived processes", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-managed-device-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    process.env.MIRU_AUTH_BASE_URL = "https://auth.example.test";
+    process.env.MIRU_AUTH_CLIENT_ID = "miru-test";
+
+    let call = 0;
+    globalThis.fetch = (async (input, init) => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            device_code: "setup-device-code",
+            user_code: "QWER-TYUI",
+            verification_uri: "https://verify.example.test",
+            expires_in: 600,
+            interval: 0,
+          }),
+          { status: 200 },
+        );
+      }
+      if (call === 2) {
+        return new Response(
+          JSON.stringify({
+            access_token: "initial-device-token",
+            refresh_token: "initial-refresh-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+          }),
+          { status: 200 },
+        );
+      }
+      expect(String(input)).toBe("https://auth.example.test/oauth/token");
+      expect(String(init?.body)).toContain("grant_type=refresh_token");
+      return new Response(
+        JSON.stringify({
+          access_token: "refreshed-device-token",
+          refresh_token: "refreshed-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await runSetup({ device: true, force: true, interactive: true });
+    expect(process.env.TAKARA_API_KEY).toBe("initial-device-token");
+
+    await saveStoredCredentials({
+      kind: "device_code",
+      accessToken: "initial-device-token",
+      refreshToken: "initial-refresh-token",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    const loaded = await loadStoredCredentials();
+    expect(loaded).toBe(true);
+    expect(process.env.TAKARA_API_KEY).toBe("refreshed-device-token");
+
+    const stored = JSON.parse(await readFile(join(credDir, "credentials.json"), "utf-8")) as {
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(stored.access_token).toBe("refreshed-device-token");
+    expect(stored.refresh_token).toBe("refreshed-refresh-token");
+  });
 });
 
 describe("parseSetupCliArgs", () => {
   test("parses Takara --key / -k and --force", () => {
     expect(parseSetupCliArgs(["--key", "tok", "--force"]).args).toEqual({
       apiKey: "tok",
+      device: false,
       force: true,
       clear: false,
       sagemaker: false,
@@ -202,10 +378,23 @@ describe("parseSetupCliArgs", () => {
     expect(parseSetupCliArgs(["-k", "tok"]).args.apiKey).toBe("tok");
   });
 
+  test("parses --device", () => {
+    expect(parseSetupCliArgs(["--device", "--force"]).args).toEqual({
+      apiKey: undefined,
+      device: true,
+      force: true,
+      clear: false,
+      sagemaker: false,
+      sagemakerArn: undefined,
+      profile: undefined,
+    });
+  });
+
   test("parses SageMaker flags and implies sagemaker from --arn", () => {
     const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
     expect(parseSetupCliArgs(["--sagemaker", "--arn", arn, "--profile", "miru"]).args).toEqual({
       apiKey: undefined,
+      device: false,
       force: false,
       clear: false,
       sagemaker: true,
@@ -230,13 +419,26 @@ describe("parseSetupCliArgs", () => {
     expect(parseSetupCliArgs(["--arn", arn, "--key", "tok"]).error).toBe("sagemaker_with_key");
   });
 
+  test("rejects combining --device with --key", () => {
+    expect(parseSetupCliArgs(["--device", "--key", "tok"]).error).toBe("device_with_key");
+  });
+
+  test("rejects combining --device with --sagemaker", () => {
+    expect(parseSetupCliArgs(["--device", "--sagemaker"]).error).toBe("device_with_sagemaker");
+  });
+
   test("rejects combining --clear with --key", () => {
     expect(parseSetupCliArgs(["--clear", "--key", "tok"]).error).toBe("clear_with_key");
+  });
+
+  test("rejects combining --clear with --device", () => {
+    expect(parseSetupCliArgs(["--clear", "--device"]).error).toBe("clear_with_key");
   });
 
   test("parses --clear alone", () => {
     expect(parseSetupCliArgs(["--clear"]).args).toEqual({
       apiKey: undefined,
+      device: false,
       force: false,
       clear: true,
       sagemaker: false,

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -240,6 +240,59 @@ describe("setup credentials", () => {
     expect(process.env.TAKARA_API_KEY).toBe("device-access-token");
   });
 
+  test("ensureCredentials device bootstrap keeps human auth UI off stdout", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-stdout-clean-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    process.env.MIRU_AUTH_BASE_URL = "https://auth.example.test";
+    process.env.MIRU_AUTH_CLIENT_ID = "miru-test";
+    process.env.MIRU_OPEN_BROWSER = "0";
+
+    let call = 0;
+    globalThis.fetch = (async (input) => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            device_code: "device-code",
+            user_code: "ABCD-EFGH",
+            verification_uri: "https://verify.example.test",
+            expires_in: 600,
+            interval: 0,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "device-access-token",
+          refresh_token: "device-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    let stdout = "";
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+      stdout += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+      return (originalWrite as (chunk: string | Uint8Array, ...args: unknown[]) => boolean)(
+        chunk,
+        ...args,
+      );
+    }) as typeof process.stdout.write;
+
+    try {
+      await ensureCredentials({ interactive: true });
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    expect(process.env.TAKARA_API_KEY).toBe("device-access-token");
+    expect(stdout).not.toMatch(/Takara credentials|device-code|Open https:\/\/verify|Saved credentials/i);
+  });
+
   test("ensureCredentials falls back to re-auth when refresh fails and interactive login is allowed", async () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-setup-refresh-fallback-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;


### PR DESCRIPTION
## Summary
- implement the PRD-311 device auth flow with automatic MCP/bootstrap login, refresh handling, and recovery
- add repo-local Codex plugin packaging plus Claude Code and Cursor plugin packaging manifests
- add shared Miru skill/rules metadata and update tests to cover host plugin manifests

## Testing
- bun run typecheck
- bun test tests/plugin-manifest.test.ts tests/setup.test.ts tests/credentials.test.ts tests/mcp-runtime.test.ts tests/validate-api-key.test.ts
- claude plugin validate .claude-plugin/plugin.json
- claude plugin validate .

Ref PRD-311