### PR TITLE
feat: prd 276 index freshness cache invalidation

### DIFF
--- a/src/mcp/index-cache.ts
+++ b/src/mcp/index-cache.ts
@@ -1,5 +1,7 @@
 import { watch } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
+import { walkFiles } from "../index/file-walker.ts";
+import { getExtensions } from "../index/files.ts";
 import { normalizeRelativePath, relativePathFromRoot } from "../index/incremental.ts";
 import { MiruIndex } from "../miru-index.ts";
 import type { ContentType } from "../types.ts";
@@ -120,6 +122,11 @@ export class IndexCache {
       if (!isGitUrl(source)) {
         await index.saveToCache(resolve(source));
       }
+      if (index.loadedFromDisk) {
+        // Await reconciliation here (not fire-and-forget) so callers of `get()`
+        // never observe an index that's stale relative to what's on disk.
+        await this.checkAndQueueStaleFiles(source, index, cacheKey);
+      }
       return index;
     })();
 
@@ -129,7 +136,6 @@ export class IndexCache {
       .then((index) => {
         entry.index = index;
         this.maybeStartWatcher(source);
-        void this.flushFileUpdates(cacheKey, source);
         return index;
       })
       .catch(() => {
@@ -162,7 +168,7 @@ export class IndexCache {
     if (!entry.flushQueued) {
       entry.flushQueued = true;
       queueMicrotask(() => {
-        this.flushFileUpdates(cacheKey, source);
+        void this.flushFileUpdates(cacheKey, source);
       });
     }
   }
@@ -219,10 +225,10 @@ export class IndexCache {
     this.scheduleFlush(cacheKey, source, entry);
   }
 
-  private flushFileUpdates(cacheKey: string, source: string): void {
+  private flushFileUpdates(cacheKey: string, source: string): Promise<void> {
     const entry = this.entries.get(cacheKey);
     if (!entry) {
-      return;
+      return Promise.resolve();
     }
     entry.flushQueued = false;
 
@@ -264,6 +270,57 @@ export class IndexCache {
     };
 
     entry.updateChain = entry.updateChain.then(run, run);
+    return entry.updateChain;
+  }
+
+  private async checkAndQueueStaleFiles(
+    source: string,
+    index: MiruIndex,
+    cacheKey: string,
+  ): Promise<void> {
+    if (isGitUrl(source)) {
+      return;
+    }
+
+    const root = index.root;
+    if (!root) {
+      return;
+    }
+
+    const storedMtimes = index.getStoredFileMtimes();
+    const entry = this.ensureEntry(cacheKey, source);
+
+    try {
+      await Promise.all(
+        [...storedMtimes].map(async ([filePath, storedMtime]) => {
+          try {
+            const currentStat = await Bun.file(resolve(root, filePath)).stat();
+            const currentMtime = Math.floor(currentStat.mtime?.getTime() ?? 0);
+
+            if (currentMtime !== storedMtime) {
+              entry.pendingPaths.add(normalizeRelativePath(filePath));
+            }
+          } catch {
+            entry.pendingPaths.add(normalizeRelativePath(filePath));
+          }
+        }),
+      );
+
+      // Files created on disk while this index wasn't loaded (or never indexed
+      // before) have no entry in `storedMtimes` and are otherwise invisible to
+      // the mtime comparison above; a directory walk is the only way to find them.
+      const extensions = getExtensions(index.contentTypes);
+      for await (const absolutePath of walkFiles(root, extensions)) {
+        const relativePath = normalizeRelativePath(relative(root, absolutePath));
+        if (!storedMtimes.has(relativePath)) {
+          entry.pendingPaths.add(relativePath);
+        }
+      }
+
+      if (entry.pendingPaths.size > 0) {
+        await this.flushFileUpdates(cacheKey, source);
+      }
+    } catch {}
   }
 
   private maybeStartWatcher(source: string): void {

--- a/src/miru-index.ts
+++ b/src/miru-index.ts
@@ -60,7 +60,7 @@ export class MiruIndex {
    * Absolute path to the indexed tree on disk, or `null` for git-only indexes
    * (clone is deleted after indexing; incremental updates need a local root).
    */
-  private readonly root: string | null;
+  private readonly _root: string | null;
 
   /** Content kinds indexed at build time (e.g. `code`, `markdown`). */
   private readonly content: ContentType[];
@@ -71,6 +71,9 @@ export class MiruIndex {
   /** Language tag → chunk indices, for `filterLanguages` in search. */
   private languageMapping: Map<string, number[]>;
 
+  /** Stored file mtimes (file path → mtime_ms) for cache freshness checking. */
+  private storedFileMtimes: Map<string, number>;
+
   /** Read-only view of indexed chunks. */
   get chunks(): Chunk[] {
     return this.chunksInternal;
@@ -79,6 +82,21 @@ export class MiruIndex {
   /** Whether this instance was loaded from a cache bundle rather than freshly built. */
   get loadedFromDisk(): boolean {
     return this.loadedFromDiskFlag;
+  }
+
+  /** Get stored file mtimes for cache validation. */
+  getStoredFileMtimes(): Map<string, number> {
+    return this.storedFileMtimes;
+  }
+
+  /** Get the root path for local indexes (null for git indexes). */
+  get root(): string | null {
+    return this._root;
+  }
+
+  /** Content kinds indexed at build time, for re-walking the tree during freshness checks. */
+  get contentTypes(): ContentType[] {
+    return this.content;
   }
 
   /**
@@ -94,15 +112,17 @@ export class MiruIndex {
     root?: string | null;
     content?: ContentType[];
     loadedFromDisk?: boolean;
+    storedFileMtimes?: Record<string, number>;
   }) {
     this.embeddings = options.embeddings;
     this.bm25Index = options.bm25Index;
     this.semanticIndex = options.semanticIndex;
     this.chunksInternal = options.chunks;
     this.embeddingModel = options.embeddingModel;
-    this.root = options.root ?? null;
+    this._root = options.root ?? null;
     this.content = options.content ?? ["code"];
     this.loadedFromDiskFlag = options.loadedFromDisk ?? false;
+    this.storedFileMtimes = new Map(Object.entries(options.storedFileMtimes ?? {}));
     this.fileMapping = new Map();
     this.languageMapping = new Map();
     this.rebuildMappings();
@@ -253,6 +273,7 @@ export class MiruIndex {
     const { bm25, semantic, chunks, metadata } = await loadCachedIndex(path);
     const content = (metadata.content_type as ContentType[]) ?? ["code"];
     const root = metadata.root_path ? String(metadata.root_path) : null;
+    const storedFileMtimes = (metadata.file_mtimes as Record<string, number>) ?? {};
 
     return new MiruIndex({
       embeddings: getEmbeddingBackend(model),
@@ -263,6 +284,7 @@ export class MiruIndex {
       root,
       content,
       loadedFromDisk: true,
+      storedFileMtimes,
     });
   }
 
@@ -275,6 +297,19 @@ export class MiruIndex {
   async save(path: string): Promise<void> {
     const paths = persistencePaths(path);
     await mkdir(paths.root, { recursive: true });
+
+    const fileMtimes: Record<string, number> = {};
+    if (this._root) {
+      for (const filePath of this.fileMapping.keys()) {
+        try {
+          const stat = await Bun.file(resolve(this._root, filePath)).stat();
+          fileMtimes[filePath] = Math.floor(stat.mtime?.getTime() ?? 0);
+        } catch {
+          fileMtimes[filePath] = 0;
+        }
+      }
+    }
+
     await saveIndexBundle({
       paths,
       bm25: this.bm25Index,
@@ -282,7 +317,7 @@ export class MiruIndex {
       chunks: this.chunks.map(chunkToDict),
       metadata: {
         index_epoch: indexCacheEpoch(),
-        root_path: this.root,
+        root_path: this._root,
         time: Date.now() / 1000,
         embedding_model: this.embeddingModel,
         embedding_dimensions:
@@ -290,6 +325,7 @@ export class MiruIndex {
         embedding_provider: "openai",
         content_type: this.content,
         file_paths: [...this.fileMapping.keys()].sort(),
+        file_mtimes: fileMtimes,
       },
     });
   }
@@ -313,7 +349,7 @@ export class MiruIndex {
    * index, and mappings in place; clears `loadedFromDisk` since data changed.
    */
   async applyFileChanges(relativePaths: readonly string[]): Promise<void> {
-    if (!this.root) {
+    if (!this._root) {
       throw new Error("Incremental update requires a local index with root_path set.");
     }
     if (relativePaths.length === 0) {
@@ -321,7 +357,7 @@ export class MiruIndex {
     }
 
     const updated = await applyIncrementalFileChanges({
-      root: this.root,
+      root: this._root,
       content: this.content,
       embeddings: this.embeddings,
       chunks: this.chunksInternal,

--- a/tests/incremental-integration.test.ts
+++ b/tests/incremental-integration.test.ts
@@ -55,8 +55,9 @@ type CacheEntryInternal = {
 };
 
 type IndexCacheTestAccess = {
-  ensureEntry(cacheKey: string): CacheEntryInternal;
+  ensureEntry(cacheKey: string, source?: string): CacheEntryInternal;
   noteFileChange(source: string, filename: string | null | undefined): void;
+  checkAndQueueStaleFiles(source: string, index: MiruIndex, cacheKey: string): Promise<void>;
 };
 
 function cacheInternals(cache: IndexCache): IndexCacheTestAccess {
@@ -217,6 +218,135 @@ describe("incremental integration", () => {
         rerank: false,
       });
       expect(authHit[0]?.chunk.file_path).toBe("src/auth.ts");
+
+      cache.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("IndexCache freshness check detects new files added while the index wasn't loaded", async () => {
+    const root = await buildTempRepo();
+    const resolvedRoot = resolve(root);
+    try {
+      const embeddings = trackingEmbeddings();
+      const built = await createIndexFromPath(resolvedRoot, embeddings, ["code"], resolvedRoot);
+
+      // Snapshot mtimes for the files that exist now, simulating a cache bundle
+      // that was saved before the new file below was ever created.
+      const storedFileMtimes: Record<string, number> = {};
+      for (const rel of ["src/auth.ts", "src/utils.ts"]) {
+        const stat = await Bun.file(join(resolvedRoot, rel)).stat();
+        storedFileMtimes[rel] = Math.floor(stat.mtime?.getTime() ?? 0);
+      }
+
+      const index = new MiruIndex({
+        embeddings,
+        bm25Index: built.bm25,
+        semanticIndex: built.semantic,
+        chunks: built.chunks,
+        embeddingModel: embeddings.model,
+        root: resolvedRoot,
+        content: ["code"],
+        loadedFromDisk: true,
+        storedFileMtimes,
+      });
+
+      // Created after the snapshot -- absent from storedFileMtimes entirely,
+      // so the mtime-comparison loop alone would never notice it.
+      await writeFile(
+        join(resolvedRoot, "src/newfile.ts"),
+        "export function brandNewMiruFeature() {\n  return 'miruFreshFileToken';\n}\n",
+        "utf-8",
+      );
+
+      const cache = new IndexCache(["code"]);
+      const cacheKey = computeSourceCacheKey(resolvedRoot);
+      const internals = cacheInternals(cache);
+      const entry = internals.ensureEntry(cacheKey, resolvedRoot);
+      entry.index = index;
+      entry.task = Promise.resolve(index);
+
+      embeddings.resetEmbedCount();
+      await internals.checkAndQueueStaleFiles(resolvedRoot, index, cacheKey);
+
+      expect(embeddings.documentEmbedCount).toBeGreaterThan(0);
+      expect(embeddings.lastEmbeddedTexts.some((text) => text.includes("miruFreshFileToken"))).toBe(
+        true,
+      );
+
+      const hit = await index.search({
+        query: "miruFreshFileToken",
+        topK: 1,
+        alpha: 0,
+        rerank: false,
+      });
+      expect(hit[0]?.chunk.file_path).toBe("src/newfile.ts");
+
+      cache.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("IndexCache freshness check for a modified file resolves fully within a single await", async () => {
+    const root = await buildTempRepo();
+    const resolvedRoot = resolve(root);
+    try {
+      const embeddings = trackingEmbeddings();
+      const built = await createIndexFromPath(resolvedRoot, embeddings, ["code"], resolvedRoot);
+
+      const storedFileMtimes: Record<string, number> = {};
+      for (const rel of ["src/auth.ts", "src/utils.ts"]) {
+        const stat = await Bun.file(join(resolvedRoot, rel)).stat();
+        storedFileMtimes[rel] = Math.floor(stat.mtime?.getTime() ?? 0);
+      }
+
+      const index = new MiruIndex({
+        embeddings,
+        bm25Index: built.bm25,
+        semanticIndex: built.semantic,
+        chunks: built.chunks,
+        embeddingModel: embeddings.model,
+        root: resolvedRoot,
+        content: ["code"],
+        loadedFromDisk: true,
+        storedFileMtimes,
+      });
+
+      // Guard against coarse-grained filesystem mtime resolution.
+      await new Promise((r) => setTimeout(r, 20));
+      await writeFile(
+        join(resolvedRoot, "src/auth.ts"),
+        "export function authenticateUser() {\n  return 'miruRaceFixToken';\n}\n",
+        "utf-8",
+      );
+
+      const cache = new IndexCache(["code"]);
+      const cacheKey = computeSourceCacheKey(resolvedRoot);
+      const internals = cacheInternals(cache);
+      const entry = internals.ensureEntry(cacheKey, resolvedRoot);
+      entry.index = index;
+      entry.task = Promise.resolve(index);
+
+      embeddings.resetEmbedCount();
+      await internals.checkAndQueueStaleFiles(resolvedRoot, index, cacheKey);
+
+      // No queueMicrotask/setTimeout polling here: a caller that awaits
+      // checkAndQueueStaleFiles (as IndexCache.get now does via startBuild)
+      // must observe the fully reconciled index right away, not a stale one
+      // still mid-flush on a separate microtask chain.
+      expect(entry.pendingPaths.size).toBe(0);
+      expect(embeddings.documentEmbedCount).toBeGreaterThan(0);
+
+      const hit = await index.search({
+        query: "miruRaceFixToken",
+        topK: 1,
+        alpha: 0,
+        rerank: false,
+      });
+      expect(hit[0]?.chunk.file_path).toBe("src/auth.ts");
+      expect(hit[0]?.chunk.content).toContain("miruRaceFixToken");
 
       cache.close();
     } finally {

--- a/tests/incremental-integration.test.ts
+++ b/tests/incremental-integration.test.ts
@@ -254,10 +254,9 @@ describe("incremental integration", () => {
 
       // Created after the snapshot -- absent from storedFileMtimes entirely,
       // so the mtime-comparison loop alone would never notice it.
-      await writeFile(
+      await Bun.write(
         join(resolvedRoot, "src/newfile.ts"),
         "export function brandNewMiruFeature() {\n  return 'miruFreshFileToken';\n}\n",
-        "utf-8",
       );
 
       const cache = new IndexCache(["code"]);
@@ -316,10 +315,9 @@ describe("incremental integration", () => {
 
       // Guard against coarse-grained filesystem mtime resolution.
       await new Promise((r) => setTimeout(r, 20));
-      await writeFile(
+      await Bun.write(
         join(resolvedRoot, "src/auth.ts"),
         "export function authenticateUser() {\n  return 'miruRaceFixToken';\n}\n",
-        "utf-8",
       );
 
       const cache = new IndexCache(["code"]);


### PR DESCRIPTION
## Describe your changes

- What: Fixed the disk-cache freshness reconciliation in IndexCache (src/mcp/index-cache.ts) and MiruIndex (src/miru-index.ts):
  - The staleness check now also walks the indexed directory tree (scoped to the index's content-type extensions) to detect files created on disk that have no prior mtime entry — previously it only compared mtimes for files already known to the saved index, so new files created while the MCP server was offline were silently invisible to search.
  - IndexCache.get() now awaits the reconciliation as part of the build task itself, instead of firing it off unawaited. Previously a caller could get back an index before the stale/new-file re-indexing had actually finished, so the first query after a restart could silently serve stale results.
  - The per-file mtime stat checks now run concurrently via Promise.all instead of one at a time.
  - Added two integration tests covering new-file detection and the await-ordering fix; test file writes switched to Bun.write to match the codebase's Bun-native convention.
- Why: The freshness/cache-invalidation feature only reacted to modified or deleted files against its own stored mtime map — files added between MCP server sessions (or before this feature existed) were never picked up until an unrelated trigger touched them, so search results could miss recently added code indefinitely. The fire-and-forget reconciliation also created a race where results could be served before the cache had actually caught up.

## Issue ticket number and link
[PRD-278](https://linear.app/takara-ai/issue/PRD-276/strengthen-index-freshness-and-cache-invalidation)

## Checklist before requesting a review
- [x] PR title follows conventional commit format (e.g., `feat: add user authentication`, `fix: resolve API timeout`)
- [x] I have performed a self-review of my code
- [x] Tests pass
- [x] Documentation updated if needed
