### PR TITLE
feat(embeddings): add self-hosted AWS SageMaker embedding backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ TAKARA_API_KEY=
 
 # MIRU_OPENAI_BASE_URL=https://infer.takara.ai/v1
 # MIRU_OPENAI_EMBEDDING_MODEL=ds1-miru-int8
+# Enterprise self-hosted SageMaker: see docs/self-hosted-sagemaker.md
+# MIRU_SAGEMAKER_ENDPOINT_ARN=
+# AWS_PROFILE=
 # MIRU_EMBEDDING_DIMENSIONS=256
 # MIRU_FLOAT_VECTORS=1  # debug/precision baseline only; default is int8
 # MIRU_EMBEDDING_BATCH_SIZE=32

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Miru sends **file contents** to the [Takara inference API](https://takara.ai) wh
 
 If you index proprietary code, make sure that sending snippets to Takara's endpoint fits your security and compliance requirements. `MIRU_WORKSPACE_ROOT` is an opt-in boundary for MCP local `repo` paths only, and restricts indexing to a single workspace directory when set.
 
+Enterprise self-hosted embeddings (no Takara egress): see [docs/self-hosted-sagemaker.md](docs/self-hosted-sagemaker.md).
+
 ## Benchmark mode
 
 Optional measurement of how many tokens Miru saves versus a simple Grep workflow (ripgrep + reading the top matched file). Useful when evaluating Miru; leave it off day-to-day. Only local repo paths are compared — git URL repos skip the comparison and return `benchmark_skipped: "local_repo_only"`.

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "miru",
       "dependencies": {
+        "@aws-sdk/client-sagemaker-runtime": "^3.1090.0",
         "ignore": "^7.0.5",
         "web-tree-sitter": "^0.26.9",
         "zod": "^4.4.3",
@@ -42,6 +43,38 @@
     },
   },
   "packages": {
+    "@aws-sdk/client-sagemaker-runtime": ["@aws-sdk/client-sagemaker-runtime@3.1090.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-node": "^3.972.70", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-OIDrjs6ZdV18WqMaTqN3pN84t6Cv3GXyxJecxp/L8S5+ENKNDJF/2/wIDxeJJRYk6D0C+XBtUkR2V64PcPoK0Q=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.975.3", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.61", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.4", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-login": "^3.972.66", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.70", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-ini": "^3.973.4", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.3", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/token-providers": "3.1088.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.41", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1088.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
@@ -62,6 +95,18 @@
 
     "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
 
+    "@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.10", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.6", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
@@ -69,6 +114,8 @@
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -133,6 +180,8 @@
     "tree-sitter-solidity": ["tree-sitter-solidity@1.2.13", "", { "dependencies": { "node-addon-api": "^8.2.2", "node-gyp-build": "^4.8.2", "yarn": "^1.22.21" }, "peerDependencies": { "tree-sitter": "^0.25.0" } }, "sha512-nO2AbcAuz2Qba8JnPNe/3FVjRRvGY3ApxSJ8UPIzfynJm4PYCMbBoXxxbprvMgjCbGYR/ZrHGIPKzXV7zBa+lQ=="],
 
     "tree-sitter-typescript": ["tree-sitter-typescript@0.23.2", "", { "dependencies": { "node-addon-api": "^8.2.2", "node-gyp-build": "^4.8.2", "tree-sitter-javascript": "^0.23.1" }, "peerDependencies": { "tree-sitter": "^0.21.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/docs/self-hosted-sagemaker.md
+++ b/docs/self-hosted-sagemaker.md
@@ -1,12 +1,22 @@
 # Self-hosted embeddings (AWS SageMaker)
 
-Enterprise guide: run Miru against your own SageMaker embedding endpoint instead of Takara’s hosted API (`infer.takara.ai`).
+Run Miru against your own SageMaker embedding endpoint instead of Takara’s hosted API (`infer.takara.ai`).
 
 The embedding model is sold on AWS Marketplace:
 
 **[Takara DS1 Miru (int8) — AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-la5olwsicr6ue)**
 
-Subscribe there, deploy the model package as a SageMaker endpoint in your account, then point Miru at that endpoint.
+## Overview
+
+
+| Step | Who       | What                                                             |
+| ---- | --------- | ---------------------------------------------------------------- |
+| 1    | AWS admin | Subscribe on Marketplace and deploy a SageMaker endpoint         |
+| 2    | AWS admin | Create an invoke-only IAM user / profile (runbook below)         |
+| 3    | Developer | `miru setup --sagemaker` — Miru validates and saves the endpoint |
+
+
+Miru **never** creates IAM users or writes `~/.aws`. It only inherits a profile you already have and checks that it can call the endpoint.
 
 ## One mode at a time
 
@@ -17,22 +27,54 @@ Miru stores **either** a Takara API key **or** a SageMaker endpoint — never bo
 
 You do not need `--clear` when switching; the other mode is purged automatically.
 
-## Prerequisites
+## 1. Deploy the Marketplace endpoint
 
-- A SageMaker endpoint deployed from the [Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-la5olwsicr6ue) (e.g. `ds1-miru-int8` via `ds1-tei`)
-- An AWS identity that can call `sagemaker:InvokeEndpoint` on that endpoint
-- AWS CLI profile already configured (Miru never creates or writes `~/.aws`)
+1. Open the [Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-la5olwsicr6ue)
+2. Subscribe and deploy the model package as a SageMaker endpoint in your account
+3. Copy the endpoint ARN — it looks like:
 
-```bash
-aws configure --profile miru
+```text
+arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>
 ```
 
-## Switch from Takara to SageMaker
+
+
+## 2. Create an invoke-only AWS profile (admin runbook)
+
+You need an AWS identity that can call `sagemaker:InvokeEndpoint` on that ARN. The simplest path for a laptop / CI user is a **least-privilege IAM user** scoped to that one endpoint, installed as a named profile.
+
+From a checkout of this repo, with the [AWS CLI](https://docs.aws.amazon.com/cli/) available and **admin** credentials in your current shell:
+
+```bash
+bun run sagemaker:create-invoke-user -- \
+  --endpoint-arn arn:aws:sagemaker:<region>:<account-id>:endpoint/<name> \
+  --profile miru
+```
+
+That script (`scripts/create-sagemaker-invoke-user.ts`):
+
+1. Creates an IAM user tagged for this purpose (or reuses one with the same name)
+2. Attaches an inline policy allowing **only** `sagemaker:InvokeEndpoint` on that ARN
+3. Creates an access key and writes it into `~/.aws` as the named profile (`miru` by default)
+
+Optional flags: `--user-name <name>`, `--profile <name>` (alias: `--arn` for the endpoint).
+
+Prefer SSO / IAM roles in production if your org requires it — the runbook script is the easy start with long-lived keys. Rotate or delete keys when someone leaves.
+
+Smoke-test invoke (optional):
+
+```bash
+bun run sagemaker:auth-check -- --arn arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>
+```
+
+
+
+## 3. Point Miru at the endpoint
 
 ```bash
 miru setup --sagemaker \
   --arn arn:aws:sagemaker:<region>:<account-id>:endpoint/<name> \
-  --aws-profile miru
+  --profile miru
 ```
 
 Or run `miru setup --sagemaker` and answer the prompts.
@@ -43,7 +85,7 @@ Or run `miru setup --sagemaker` and answer the prompts.
 2. Invokes the endpoint once to confirm auth and that it returns embeddings
 3. Saves the SageMaker config and **deletes any stored Takara API key**
 
-After a successful setup, indexing and search embed via SageMaker — no egress to `infer.takara.ai`.
+After that, indexing and search embed via SageMaker — no egress to `infer.takara.ai`.
 
 If `TAKARA_API_KEY` is still set in your shell or `.env.local`, remove it there too so it cannot conflict later.
 
@@ -61,11 +103,13 @@ Also unset any `MIRU_SAGEMAKER_*` variables if you set them in the environment o
 
 Prefer `miru setup --sagemaker` so auth is checked automatically. You can also set:
 
-| Variable | Purpose |
-| --- | --- |
-| `MIRU_SAGEMAKER_ENDPOINT_ARN` | `arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>` |
-| `MIRU_SAGEMAKER_ENDPOINT_NAME` + `MIRU_SAGEMAKER_REGION` | Alternative to the ARN |
-| `AWS_PROFILE` / `AWS_ACCESS_KEY_ID` / … | Standard AWS credential chain |
+
+| Variable                                                 | Purpose                                                   |
+| -------------------------------------------------------- | --------------------------------------------------------- |
+| `MIRU_SAGEMAKER_ENDPOINT_ARN`                            | `arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>` |
+| `MIRU_SAGEMAKER_ENDPOINT_NAME` + `MIRU_SAGEMAKER_REGION` | Alternative to the ARN                                    |
+| `AWS_PROFILE` / `AWS_ACCESS_KEY_ID` / …                  | Standard AWS credential chain                             |
+
 
 Optional TEI-style knobs: `MIRU_SAGEMAKER_NORMALIZE`, `MIRU_SAGEMAKER_TRUNCATE`, `MIRU_SAGEMAKER_TRUNCATION_DIRECTION`, `MIRU_SAGEMAKER_PROMPT_NAME`.
 

--- a/docs/self-hosted-sagemaker.md
+++ b/docs/self-hosted-sagemaker.md
@@ -1,0 +1,72 @@
+# Self-hosted embeddings (AWS SageMaker)
+
+Enterprise guide: run Miru against your own SageMaker embedding endpoint instead of Takara’s hosted API (`infer.takara.ai`).
+
+The embedding model is sold on AWS Marketplace:
+
+**[Takara DS1 Miru (int8) — AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-la5olwsicr6ue)**
+
+Subscribe there, deploy the model package as a SageMaker endpoint in your account, then point Miru at that endpoint.
+
+## One mode at a time
+
+Miru stores **either** a Takara API key **or** a SageMaker endpoint — never both.
+
+- `miru setup --sagemaker …` **removes** any stored Takara API key
+- `miru setup` (Takara) **removes** any stored SageMaker endpoint
+
+You do not need `--clear` when switching; the other mode is purged automatically.
+
+## Prerequisites
+
+- A SageMaker endpoint deployed from the [Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-la5olwsicr6ue) (e.g. `ds1-miru-int8` via `ds1-tei`)
+- An AWS identity that can call `sagemaker:InvokeEndpoint` on that endpoint
+- AWS CLI profile already configured (Miru never creates or writes `~/.aws`)
+
+```bash
+aws configure --profile miru
+```
+
+## Switch from Takara to SageMaker
+
+```bash
+miru setup --sagemaker \
+  --arn arn:aws:sagemaker:<region>:<account-id>:endpoint/<name> \
+  --aws-profile miru
+```
+
+Or run `miru setup --sagemaker` and answer the prompts.
+
+**What setup does**
+
+1. Parses the endpoint ARN + AWS profile name
+2. Invokes the endpoint once to confirm auth and that it returns embeddings
+3. Saves the SageMaker config and **deletes any stored Takara API key**
+
+After a successful setup, indexing and search embed via SageMaker — no egress to `infer.takara.ai`.
+
+If `TAKARA_API_KEY` is still set in your shell or `.env.local`, remove it there too so it cannot conflict later.
+
+## Switch back to Takara
+
+```bash
+miru setup
+```
+
+Enter your Takara API key. Setup validates it, saves it, and **deletes any stored SageMaker endpoint**.
+
+Also unset any `MIRU_SAGEMAKER_*` variables if you set them in the environment or `.env.local`.
+
+## Environment alternatives
+
+Prefer `miru setup --sagemaker` so auth is checked automatically. You can also set:
+
+| Variable | Purpose |
+| --- | --- |
+| `MIRU_SAGEMAKER_ENDPOINT_ARN` | `arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>` |
+| `MIRU_SAGEMAKER_ENDPOINT_NAME` + `MIRU_SAGEMAKER_REGION` | Alternative to the ARN |
+| `AWS_PROFILE` / `AWS_ACCESS_KEY_ID` / … | Standard AWS credential chain |
+
+Optional TEI-style knobs: `MIRU_SAGEMAKER_NORMALIZE`, `MIRU_SAGEMAKER_TRUNCATE`, `MIRU_SAGEMAKER_TRUNCATION_DIRECTION`, `MIRU_SAGEMAKER_PROMPT_NAME`.
+
+See `miru help setup` and `miru -h` for the same flags in the CLI.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "src",
     "grammars",
     "tokenizer",
+    "docs",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -61,9 +61,12 @@
     "benchmark:literal": "bun run scripts/benchmark-literal-tokens.ts",
     "benchmark:quality": "bun run scripts/benchmark-quality.ts",
     "benchmark:quantization": "bun run scripts/benchmark-quantization.ts",
-    "benchmark:tokenizer-ab": "bun run scripts/tokenizer-ab.ts"
+    "benchmark:tokenizer-ab": "bun run scripts/tokenizer-ab.ts",
+    "sagemaker:auth-check": "bun run scripts/sagemaker-auth-check.ts",
+    "benchmark:embedding-latency": "bun run scripts/embedding-latency-ab.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-sagemaker-runtime": "^3.1090.0",
     "ignore": "^7.0.5",
     "web-tree-sitter": "^0.26.9",
     "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "benchmark:quantization": "bun run scripts/benchmark-quantization.ts",
     "benchmark:tokenizer-ab": "bun run scripts/tokenizer-ab.ts",
     "sagemaker:auth-check": "bun run scripts/sagemaker-auth-check.ts",
+    "sagemaker:create-invoke-user": "bun run scripts/create-sagemaker-invoke-user.ts",
     "benchmark:embedding-latency": "bun run scripts/embedding-latency-ab.ts"
   },
   "dependencies": {

--- a/scripts/create-sagemaker-invoke-user.ts
+++ b/scripts/create-sagemaker-invoke-user.ts
@@ -169,9 +169,7 @@ async function main(): Promise<void> {
   console.log(`IAM user: ${userName}`);
   console.log("");
   console.log("Next — point Miru at the endpoint (purges any stored Takara API key):");
-  console.log(
-    `  miru setup --sagemaker --arn ${args.endpointArn} --profile ${args.profile}`,
-  );
+  console.log(`  miru setup --sagemaker --arn ${args.endpointArn} --profile ${args.profile}`);
   console.log("");
   console.log("Optional smoke test:");
   console.log(`  bun run sagemaker:auth-check -- --arn ${args.endpointArn}`);

--- a/scripts/create-sagemaker-invoke-user.ts
+++ b/scripts/create-sagemaker-invoke-user.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+/**
+ * Admin runbook: create a least-privilege IAM user that can only InvokeEndpoint on one
+ * SageMaker endpoint, then install a named AWS profile with the access keys.
+ *
+ * This is NOT part of `miru setup`. Miru only inherits credentials — it never creates
+ * IAM users or writes ~/.aws. Run this (or equivalent IdP/SSO role setup) once as an
+ * account admin, then point Miru at the profile.
+ *
+ * Requires: AWS CLI, and caller credentials with iam:CreateUser / PutUserPolicy /
+ * CreateAccessKey (typically an admin role).
+ *
+ * Usage:
+ *   bun run scripts/create-sagemaker-invoke-user.ts \
+ *     --endpoint-arn arn:aws:sagemaker:us-east-1:123456789012:endpoint/my-endpoint \
+ *     --profile miru
+ *
+ * See docs/self-hosted-sagemaker.md
+ */
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseSageMakerEndpointArn } from "../src/embeddings/sagemaker.ts";
+
+type Args = {
+  endpointArn: string;
+  profile: string;
+  userName?: string;
+};
+
+function getArg(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  if (i === -1) {
+    return undefined;
+  }
+  const v = argv[i + 1];
+  if (!v || v.startsWith("--")) {
+    return undefined;
+  }
+  return v;
+}
+
+function usageError(message: string): never {
+  console.error(`Error: ${message}`);
+  console.error("");
+  console.error(
+    "Usage: bun run scripts/create-sagemaker-invoke-user.ts --endpoint-arn <arn> [--profile miru] [--user-name <name>]",
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): Args {
+  const endpointArn = getArg(argv, "--endpoint-arn") ?? getArg(argv, "--arn");
+  if (!endpointArn) {
+    usageError("--endpoint-arn is required");
+  }
+  return {
+    endpointArn,
+    profile: getArg(argv, "--profile") ?? "miru",
+    userName: getArg(argv, "--user-name"),
+  };
+}
+
+async function runAws(args: string[]): Promise<string> {
+  const proc = Bun.spawn(["aws", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`aws ${args.join(" ")} failed:\n${stderr || stdout}`);
+  }
+  return stdout.trim();
+}
+
+async function ensureUser(userName: string, endpointName: string): Promise<void> {
+  try {
+    await runAws([
+      "iam",
+      "create-user",
+      "--user-name",
+      userName,
+      "--tags",
+      "Key=Purpose,Value=SageMakerInvokeOnly",
+      `Key=Endpoint,Value=${endpointName}`,
+      "Key=ManagedBy,Value=miru-create-sagemaker-invoke-user",
+    ]);
+    console.log(`Created IAM user: ${userName}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/EntityAlreadyExists|already exists/i.test(message)) {
+      throw error;
+    }
+    console.log(`Using existing IAM user: ${userName}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const { region, endpointName } = parseSageMakerEndpointArn(args.endpointArn);
+  const userName =
+    args.userName ??
+    `miru-invoke-${endpointName}`.replace(/[^a-zA-Z0-9+=,.@_-]/g, "-").slice(0, 64);
+
+  console.log("Creating invoke-only IAM user + AWS profile for Miru.");
+  console.log(`Endpoint: ${args.endpointArn}`);
+  console.log(`Profile:  ${args.profile}`);
+  console.log("");
+
+  await ensureUser(userName, endpointName);
+
+  const policy = {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "InvokeOnlyThisEndpoint",
+        Effect: "Allow",
+        Action: ["sagemaker:InvokeEndpoint"],
+        Resource: args.endpointArn,
+      },
+    ],
+  };
+
+  const policyPath = join(tmpdir(), `${userName}-policy.json`);
+  await Bun.write(policyPath, JSON.stringify(policy));
+  try {
+    await runAws([
+      "iam",
+      "put-user-policy",
+      "--user-name",
+      userName,
+      "--policy-name",
+      "sagemaker-invoke-only-this-endpoint",
+      "--policy-document",
+      `file://${policyPath}`,
+    ]);
+  } finally {
+    await unlink(policyPath).catch(() => undefined);
+  }
+  console.log(`Attached invoke-only policy for ${args.endpointArn}`);
+
+  const keyRaw = await runAws([
+    "iam",
+    "create-access-key",
+    "--user-name",
+    userName,
+    "--output",
+    "json",
+  ]);
+  const key = JSON.parse(keyRaw) as {
+    AccessKey: { AccessKeyId: string; SecretAccessKey: string };
+  };
+  const { AccessKeyId, SecretAccessKey } = key.AccessKey;
+
+  await runAws(["configure", "set", "aws_access_key_id", AccessKeyId, "--profile", args.profile]);
+  await runAws([
+    "configure",
+    "set",
+    "aws_secret_access_key",
+    SecretAccessKey,
+    "--profile",
+    args.profile,
+  ]);
+  await runAws(["configure", "set", "region", region, "--profile", args.profile]);
+
+  console.log("");
+  console.log(`Installed AWS profile: ${args.profile}`);
+  console.log(`IAM user: ${userName}`);
+  console.log("");
+  console.log("Next — point Miru at the endpoint (purges any stored Takara API key):");
+  console.log(
+    `  miru setup --sagemaker --arn ${args.endpointArn} --profile ${args.profile}`,
+  );
+  console.log("");
+  console.log("Optional smoke test:");
+  console.log(`  bun run sagemaker:auth-check -- --arn ${args.endpointArn}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/embedding-latency-ab.ts
+++ b/scripts/embedding-latency-ab.ts
@@ -1,0 +1,122 @@
+/**
+ * A/B latency check: Takara cloud vs self-hosted SageMaker, same query text, same process.
+ * Requires both TAKARA_API_KEY and MIRU_SAGEMAKER_ENDPOINT_ARN to be resolvable (env, .env.local,
+ * or `miru setup` credentials.json) — whichever is missing gets skipped rather than failing.
+ *
+ * Usage:
+ *   bun run scripts/embedding-latency-ab.ts
+ *   bun run scripts/embedding-latency-ab.ts --text "how does auth middleware work" --iterations 8
+ */
+import { loadStoredCredentials } from "../src/credentials.ts";
+import { OpenAIEmbeddingBackend, resolveTakaraEmbeddingModel } from "../src/embeddings/openai.ts";
+import { createSageMakerClient, resolveSageMakerConfig } from "../src/embeddings/sagemaker.ts";
+import { hasTakaraApiKeyInEnv, normalizeTakaraApiKeyEnv } from "../src/env.ts";
+import { loadEnvFiles } from "../src/env-files.ts";
+
+await loadEnvFiles();
+normalizeTakaraApiKeyEnv();
+await loadStoredCredentials();
+
+const args = process.argv.slice(2);
+let text = "how does the authentication middleware work";
+let iterations = 5;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--text" && args[i + 1]) {
+    text = args[++i] as string;
+  } else if (args[i] === "--iterations" && args[i + 1]) {
+    iterations = Number(args[++i]) || iterations;
+  }
+}
+
+interface Timing {
+  label: string;
+  dims: number;
+  samples: number[];
+  error?: string;
+}
+
+async function timeBackend(label: string, backend: OpenAIEmbeddingBackend): Promise<Timing> {
+  try {
+    await backend.embedQuery(text); // warm-up: excludes one-time TCP/TLS setup from steady state
+    const samples: number[] = [];
+    for (let i = 0; i < iterations; i++) {
+      const started = performance.now();
+      await backend.embedQuery(text);
+      samples.push(performance.now() - started);
+    }
+    return { label, dims: backend.dimensions, samples };
+  } catch (err) {
+    return { label, dims: 0, samples: [], error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function stats(samples: number[]): { min: number; median: number; mean: number; max: number } {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0
+      ? ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2
+      : (sorted[mid] ?? 0);
+  return {
+    min: sorted[0] ?? 0,
+    median,
+    mean: samples.reduce((a, b) => a + b, 0) / samples.length,
+    max: sorted[sorted.length - 1] ?? 0,
+  };
+}
+
+const results: Timing[] = [];
+
+if (hasTakaraApiKeyInEnv()) {
+  results.push(
+    await timeBackend(
+      "Takara",
+      new OpenAIEmbeddingBackend({ model: resolveTakaraEmbeddingModel() }),
+    ),
+  );
+} else {
+  console.log("Skipping Takara — no TAKARA_API_KEY found.");
+}
+
+const sageMakerConfig = resolveSageMakerConfig();
+if (sageMakerConfig) {
+  results.push(
+    await timeBackend(
+      `SageMaker (${sageMakerConfig.endpointName})`,
+      new OpenAIEmbeddingBackend({ client: createSageMakerClient(sageMakerConfig) }),
+    ),
+  );
+} else {
+  console.log("Skipping SageMaker — no MIRU_SAGEMAKER_ENDPOINT_ARN found.");
+}
+
+console.log("");
+console.log(`Query: "${text}"  (${iterations} timed calls each, after 1 warm-up call)`);
+console.log("");
+
+for (const result of results) {
+  if (result.error) {
+    console.log(`${result.label}: FAILED — ${result.error}`);
+    continue;
+  }
+  const s = stats(result.samples);
+  console.log(
+    `${result.label.padEnd(28)} dims=${String(result.dims).padEnd(5)} ` +
+      `min=${s.min.toFixed(0)}ms  median=${s.median.toFixed(0)}ms  ` +
+      `mean=${s.mean.toFixed(0)}ms  max=${s.max.toFixed(0)}ms`,
+  );
+}
+
+const [a, b] = results;
+if (a && b && !a.error && !b.error) {
+  const aMedian = stats(a.samples).median;
+  const bMedian = stats(b.samples).median;
+  const [faster, slower, fasterMedian, slowerMedian] =
+    aMedian <= bMedian ? [a, b, aMedian, bMedian] : [b, a, bMedian, aMedian];
+  console.log("");
+  console.log(
+    `${faster.label} is ~${(slowerMedian - fasterMedian).toFixed(0)}ms faster per query ` +
+      `(${(slowerMedian / fasterMedian).toFixed(2)}x) than ${slower.label} on this network, ` +
+      "for this query.",
+  );
+}

--- a/scripts/sagemaker-auth-check.ts
+++ b/scripts/sagemaker-auth-check.ts
@@ -1,0 +1,112 @@
+/**
+ * Smoke test for self-hosted SageMaker embedding mode. Exports of AWS creds are picked up
+ * from the environment (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN or
+ * AWS_PROFILE) via the AWS SDK's default credential chain — nothing to pass on the CLI for
+ * that part. This script only needs the endpoint ARN, then does a real InvokeEndpoint call
+ * to confirm auth + the endpoint responds like an embedding model.
+ *
+ * Usage:
+ *   bun run scripts/sagemaker-auth-check.ts --arn arn:aws:sagemaker:us-east-1:123456789012:endpoint/my-endpoint
+ *   bun run scripts/sagemaker-auth-check.ts --arn <arn> --region us-west-2 --text "hello world"
+ */
+import { embeddingDimensions } from "../src/embeddings/openai.ts";
+import {
+  createSageMakerClient,
+  parseSageMakerEndpointArn,
+  type SageMakerEmbeddingConfig,
+} from "../src/embeddings/sagemaker.ts";
+
+function usageError(message: string): never {
+  console.error(`Error: ${message}`);
+  console.error("");
+  console.error(
+    "Usage: bun run scripts/sagemaker-auth-check.ts --arn <endpoint-arn> [--region <region>] [--text <sample>]",
+  );
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+let arn: string | undefined;
+let regionOverride: string | undefined;
+let text = "miru sagemaker auth check";
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === "--arn" && args[i + 1]) {
+    arn = args[++i];
+  } else if (arg === "--region" && args[i + 1]) {
+    regionOverride = args[++i];
+  } else if (arg === "--text" && args[i + 1]) {
+    text = args[++i] as string;
+  }
+}
+
+if (!arn) {
+  usageError("--arn is required");
+}
+
+function describeCredentialEnv(): string {
+  const bits: string[] = [];
+  if (process.env.AWS_PROFILE) {
+    bits.push(`AWS_PROFILE=${process.env.AWS_PROFILE}`);
+  }
+  if (process.env.AWS_ACCESS_KEY_ID) {
+    bits.push(`AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID.slice(0, 4)}…`);
+  }
+  if (process.env.AWS_SESSION_TOKEN) {
+    bits.push("AWS_SESSION_TOKEN=<set>");
+  }
+  return bits.length > 0
+    ? bits.join(", ")
+    : "(none in env — relying on IMDS/container role, if any)";
+}
+
+let parsed: ReturnType<typeof parseSageMakerEndpointArn>;
+try {
+  parsed = parseSageMakerEndpointArn(arn);
+} catch (err) {
+  usageError(err instanceof Error ? err.message : String(err));
+}
+
+const config: SageMakerEmbeddingConfig = {
+  endpointName: parsed.endpointName,
+  region: regionOverride ?? parsed.region,
+  normalize: true,
+  truncate: true,
+  truncationDirection: "Right",
+};
+
+console.log(`Endpoint:    ${config.endpointName}`);
+console.log(`Region:      ${config.region}`);
+console.log(`Account:     ${parsed.accountId}`);
+console.log(`Credentials: ${describeCredentialEnv()}`);
+console.log("");
+console.log("Invoking endpoint…");
+
+const started = performance.now();
+try {
+  const client = createSageMakerClient(config);
+  const response = await client.createEmbeddings(text, "sagemaker-auth-check");
+  const elapsed = (performance.now() - started).toFixed(0);
+
+  const first = response.data[0]?.embedding;
+  const dims = first ? embeddingDimensions(first) : 0;
+
+  console.log(`OK — ${response.data.length} embedding(s), ${dims} dims, ${elapsed}ms`);
+  process.exit(0);
+} catch (err) {
+  const elapsed = (performance.now() - started).toFixed(0);
+  const message = err instanceof Error ? err.message : String(err);
+  const status = (err as { status?: number }).status;
+
+  console.error(`FAILED after ${elapsed}ms${status ? ` (status ${status})` : ""}: ${message}`);
+  if (status === 403) {
+    console.error("");
+    console.error("Check that the exported AWS credentials belong to an identity with");
+    console.error(`sagemaker:InvokeEndpoint on ${arn}.`);
+  } else if (status === 424) {
+    console.error("");
+    console.error("The endpoint responded, but the deployed model isn't an embedding model.");
+  }
+  process.exit(1);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -476,7 +476,7 @@ async function runCli(argv: string[]): Promise<void> {
     let clear = false;
     let sagemaker = false;
     let sagemakerArn: string | undefined;
-    let awsProfile: string | undefined;
+    let profile: string | undefined;
     for (let i = 0; i < rest.length; i++) {
       const arg = rest[i];
       if (arg === "--force") {
@@ -489,8 +489,8 @@ async function runCli(argv: string[]): Promise<void> {
         sagemaker = true;
       } else if (arg === "--arn" && rest[i + 1]) {
         sagemakerArn = rest[++i];
-      } else if (arg === "--aws-profile" && rest[i + 1]) {
-        awsProfile = rest[++i];
+      } else if (arg === "--profile" && rest[i + 1]) {
+        profile = rest[++i];
       }
     }
     if (clear) {
@@ -513,7 +513,7 @@ async function runCli(argv: string[]): Promise<void> {
       force,
       sagemaker,
       sagemakerArn,
-      awsProfile,
+      profile,
     });
     if (newlySaved) {
       const offerInstall = canPromptForCredentials() && !apiKey && !force;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import { MiruIndex } from "./miru-index.ts";
 import {
   canPromptForCredentials,
   ensureCredentials,
+  parseSetupCliArgs,
   runClearCredentials,
   runSetup,
 } from "./setup.ts";
@@ -471,52 +472,28 @@ async function runCli(argv: string[]): Promise<void> {
   }
 
   if (command === "setup") {
-    let apiKey: string | undefined;
-    let force = false;
-    let clear = false;
-    let sagemaker = false;
-    let sagemakerArn: string | undefined;
-    let profile: string | undefined;
-    for (let i = 0; i < rest.length; i++) {
-      const arg = rest[i];
-      if (arg === "--force") {
-        force = true;
-      } else if (arg === "--clear") {
-        clear = true;
-      } else if ((arg === "--key" || arg === "-k") && rest[i + 1]) {
-        apiKey = rest[++i];
-      } else if (arg === "--sagemaker") {
-        sagemaker = true;
-      } else if (arg === "--arn" && rest[i + 1]) {
-        sagemakerArn = rest[++i];
-      } else if (arg === "--profile" && rest[i + 1]) {
-        profile = rest[++i];
-      }
+    const { args, error } = parseSetupCliArgs(rest);
+    if (error === "clear_with_key") {
+      fail("miru setup --clear cannot be combined with --key.");
+      process.exit(1);
     }
-    if (clear) {
-      if (apiKey) {
-        fail("miru setup --clear cannot be combined with --key.");
-        process.exit(1);
-      }
-      await runClearCredentials();
-      return;
-    }
-    if (sagemakerArn) {
-      sagemaker = true;
-    }
-    if (sagemaker && apiKey) {
+    if (error === "sagemaker_with_key") {
       fail("miru setup --sagemaker cannot be combined with --key.");
       process.exit(1);
     }
+    if (args.clear) {
+      await runClearCredentials();
+      return;
+    }
     const { newlySaved } = await runSetup({
-      apiKey,
-      force,
-      sagemaker,
-      sagemakerArn,
-      profile,
+      apiKey: args.apiKey,
+      force: args.force,
+      sagemaker: args.sagemaker,
+      sagemakerArn: args.sagemakerArn,
+      profile: args.profile,
     });
     if (newlySaved) {
-      const offerInstall = canPromptForCredentials() && !apiKey && !force;
+      const offerInstall = canPromptForCredentials() && !args.apiKey && !args.force;
       if (offerInstall) {
         const install = await promptConfirm("Configure Miru in your coding agent now?");
         if (install) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -474,6 +474,9 @@ async function runCli(argv: string[]): Promise<void> {
     let apiKey: string | undefined;
     let force = false;
     let clear = false;
+    let sagemaker = false;
+    let sagemakerArn: string | undefined;
+    let awsProfile: string | undefined;
     for (let i = 0; i < rest.length; i++) {
       const arg = rest[i];
       if (arg === "--force") {
@@ -482,6 +485,12 @@ async function runCli(argv: string[]): Promise<void> {
         clear = true;
       } else if ((arg === "--key" || arg === "-k") && rest[i + 1]) {
         apiKey = rest[++i];
+      } else if (arg === "--sagemaker") {
+        sagemaker = true;
+      } else if (arg === "--arn" && rest[i + 1]) {
+        sagemakerArn = rest[++i];
+      } else if (arg === "--aws-profile" && rest[i + 1]) {
+        awsProfile = rest[++i];
       }
     }
     if (clear) {
@@ -492,7 +501,20 @@ async function runCli(argv: string[]): Promise<void> {
       await runClearCredentials();
       return;
     }
-    const { newlySaved } = await runSetup({ apiKey, force });
+    if (sagemakerArn) {
+      sagemaker = true;
+    }
+    if (sagemaker && apiKey) {
+      fail("miru setup --sagemaker cannot be combined with --key.");
+      process.exit(1);
+    }
+    const { newlySaved } = await runSetup({
+      apiKey,
+      force,
+      sagemaker,
+      sagemakerArn,
+      awsProfile,
+    });
     if (newlySaved) {
       const offerInstall = canPromptForCredentials() && !apiKey && !force;
       if (offerInstall) {

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -5,9 +5,15 @@ import { hasTakaraApiKeyInEnv, normalizeTakaraApiKeyEnv } from "./env.ts";
 const CREDENTIALS_FILENAME = "credentials.json";
 const CREDENTIALS_VERSION = 1;
 
+export interface StoredSageMakerCredentials {
+  endpoint_arn: string;
+  profile?: string;
+}
+
 interface StoredCredentials {
   version: number;
-  takara_api_key: string;
+  takara_api_key?: string;
+  sagemaker?: StoredSageMakerCredentials;
 }
 
 export function resolveCredentialsDir(): string {
@@ -46,7 +52,7 @@ export async function readStoredCredentials(): Promise<StoredCredentials | null>
   }
   try {
     const parsed = JSON.parse(await Bun.file(path).text()) as StoredCredentials;
-    if (parsed.version !== CREDENTIALS_VERSION || !parsed.takara_api_key) {
+    if (parsed.version !== CREDENTIALS_VERSION || (!parsed.takara_api_key && !parsed.sagemaker)) {
       return null;
     }
     return parsed;
@@ -55,27 +61,69 @@ export async function readStoredCredentials(): Promise<StoredCredentials | null>
   }
 }
 
-/** Set TAKARA_API_KEY from the user credentials file when env is unset. */
+function hydrateSageMakerEnv(sagemaker: StoredSageMakerCredentials): void {
+  process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = sagemaker.endpoint_arn;
+  if (sagemaker.profile && !process.env.AWS_PROFILE) {
+    process.env.AWS_PROFILE = sagemaker.profile;
+  }
+}
+
+/** Hydrate TAKARA_API_KEY / SageMaker env vars from the credentials file when env is unset. */
 export async function loadStoredCredentials(): Promise<boolean> {
   normalizeTakaraApiKeyEnv();
-  if (hasTakaraApiKeyInEnv()) {
+  const needsTakara = !hasTakaraApiKeyInEnv();
+  const needsSageMaker = !process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+  if (!needsTakara && !needsSageMaker) {
     return false;
   }
+
   const stored = await readStoredCredentials();
   if (!stored) {
     return false;
   }
-  process.env.TAKARA_API_KEY = stored.takara_api_key;
-  return true;
+
+  let changed = false;
+  if (needsTakara && stored.takara_api_key) {
+    process.env.TAKARA_API_KEY = stored.takara_api_key;
+    changed = true;
+  }
+  if (needsSageMaker && stored.sagemaker) {
+    hydrateSageMakerEnv(stored.sagemaker);
+    changed = true;
+  }
+  return changed;
 }
 
 export async function saveStoredCredentials(apiKey: string): Promise<string> {
   const dir = resolveCredentialsDir();
   const path = resolveCredentialsPath();
   await mkdir(dir, { recursive: true, mode: 0o700 });
+  const existing = await readStoredCredentials();
   const payload: StoredCredentials = {
     version: CREDENTIALS_VERSION,
     takara_api_key: apiKey,
+    ...(existing?.sagemaker ? { sagemaker: existing.sagemaker } : {}),
+  };
+  await Bun.write(path, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  try {
+    await chmod(path, 0o600);
+  } catch {
+    // Windows may not support Unix mode bits on all filesystems.
+  }
+  return path;
+}
+
+export async function saveStoredSageMakerCredentials(
+  sagemaker: StoredSageMakerCredentials,
+): Promise<string> {
+  const dir = resolveCredentialsDir();
+  const path = resolveCredentialsPath();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  const existing = await readStoredCredentials();
+  const payload: StoredCredentials = {
+    version: CREDENTIALS_VERSION,
+    ...(existing?.takara_api_key ? { takara_api_key: existing.takara_api_key } : {}),
+    sagemaker,
   };
   await Bun.write(path, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
   try {
@@ -95,8 +143,17 @@ export async function clearStoredCredentials(): Promise<{ cleared: boolean; path
   const stored = await readStoredCredentials();
   await Bun.file(path).delete();
 
-  if (stored && process.env.TAKARA_API_KEY === stored.takara_api_key) {
+  if (stored?.takara_api_key && process.env.TAKARA_API_KEY === stored.takara_api_key) {
     delete process.env.TAKARA_API_KEY;
+  }
+  const sagemaker = stored?.sagemaker;
+  if (sagemaker) {
+    if (process.env.MIRU_SAGEMAKER_ENDPOINT_ARN === sagemaker.endpoint_arn) {
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    }
+    if (sagemaker.profile && process.env.AWS_PROFILE === sagemaker.profile) {
+      delete process.env.AWS_PROFILE;
+    }
   }
 
   return { cleared: true, path };

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -99,16 +99,25 @@ export async function saveStoredCredentials(apiKey: string): Promise<string> {
   const path = resolveCredentialsPath();
   await mkdir(dir, { recursive: true, mode: 0o700 });
   const existing = await readStoredCredentials();
+  // Takara and SageMaker modes are mutually exclusive — saving a key drops any stored endpoint.
+  const previousSageMaker = existing?.sagemaker;
   const payload: StoredCredentials = {
     version: CREDENTIALS_VERSION,
     takara_api_key: apiKey,
-    ...(existing?.sagemaker ? { sagemaker: existing.sagemaker } : {}),
   };
   await Bun.write(path, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
   try {
     await chmod(path, 0o600);
   } catch {
     // Windows may not support Unix mode bits on all filesystems.
+  }
+  if (previousSageMaker) {
+    if (process.env.MIRU_SAGEMAKER_ENDPOINT_ARN === previousSageMaker.endpoint_arn) {
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    }
+    if (previousSageMaker.profile && process.env.AWS_PROFILE === previousSageMaker.profile) {
+      delete process.env.AWS_PROFILE;
+    }
   }
   return path;
 }
@@ -120,9 +129,10 @@ export async function saveStoredSageMakerCredentials(
   const path = resolveCredentialsPath();
   await mkdir(dir, { recursive: true, mode: 0o700 });
   const existing = await readStoredCredentials();
+  // Takara and SageMaker modes are mutually exclusive — saving an endpoint drops any stored key.
+  const previousTakaraKey = existing?.takara_api_key;
   const payload: StoredCredentials = {
     version: CREDENTIALS_VERSION,
-    ...(existing?.takara_api_key ? { takara_api_key: existing.takara_api_key } : {}),
     sagemaker,
   };
   await Bun.write(path, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
@@ -130,6 +140,9 @@ export async function saveStoredSageMakerCredentials(
     await chmod(path, 0o600);
   } catch {
     // Windows may not support Unix mode bits on all filesystems.
+  }
+  if (previousTakaraKey && process.env.TAKARA_API_KEY === previousTakaraKey) {
+    delete process.env.TAKARA_API_KEY;
   }
   return path;
 }

--- a/src/embeddings/openai.ts
+++ b/src/embeddings/openai.ts
@@ -1,5 +1,6 @@
 import { mapPool, resolveWorkerConcurrency } from "../concurrency.ts";
 import { envFirstString, envOptionalInt, resolveEmbeddingApiKey } from "../env.ts";
+import { createSageMakerClient, resolveSageMakerConfig } from "./sagemaker.ts";
 
 export const DEFAULT_EMBEDDING_MODEL = "ds1-miru-int8";
 export const DEFAULT_EMBEDDING_BASE_URL = "https://infer.takara.ai/v1";
@@ -31,11 +32,25 @@ export interface EmbeddingBackend {
   embedQuery(text: string): Promise<Float32Array>;
 }
 
-export function resolveEmbeddingModel(): string {
+/** SageMaker self-hosted mode has no configurable model name — the endpoint owns that choice. */
+export function sageMakerModelId(endpointName: string): string {
+  return `sagemaker:${endpointName}`;
+}
+
+/** Takara model name, ignoring SageMaker config — for code that talks to Takara specifically. */
+export function resolveTakaraEmbeddingModel(): string {
   return envFirstString(
     ["MIRU_OPENAI_EMBEDDING_MODEL", "OPENAI_EMBEDDING_MODEL"],
     DEFAULT_EMBEDDING_MODEL,
   );
+}
+
+export function resolveEmbeddingModel(): string {
+  const sageMaker = resolveSageMakerConfig();
+  if (sageMaker) {
+    return sageMakerModelId(sageMaker.endpointName);
+  }
+  return resolveTakaraEmbeddingModel();
 }
 
 export function resolveMaxEmbedChars(): number {
@@ -127,16 +142,16 @@ export function resolveEmbeddingBaseUrl(): string {
   ).replace(/\/$/, "");
 }
 
-interface Int8Embedding {
+export interface Int8Embedding {
   dtype: "i8";
   values: number[];
   scale: number;
   zero_point: number;
 }
 
-type EmbeddingPayload = number[] | Int8Embedding;
+export type EmbeddingPayload = number[] | Int8Embedding;
 
-interface EmbeddingResponseItem {
+export interface EmbeddingResponseItem {
   index: number;
   embedding: EmbeddingPayload;
 }
@@ -170,11 +185,11 @@ export function dequantizeEmbedding(embedding: EmbeddingPayload): Float32Array {
   throw new Error("Embedding API returned unsupported embedding format");
 }
 
-interface EmbeddingResponse {
+export interface EmbeddingResponse {
   data: EmbeddingResponseItem[];
 }
 
-interface EmbeddingClient {
+export interface EmbeddingClient {
   createEmbeddings(
     input: string[] | string,
     model: string,
@@ -510,8 +525,25 @@ function normalize(vec: Float32Array): Float32Array {
 }
 
 let defaultBackend: OpenAIEmbeddingBackend | null = null;
+let sageMakerBackend: OpenAIEmbeddingBackend | null = null;
 
 export function getEmbeddingBackend(model?: string): OpenAIEmbeddingBackend {
+  // Self-hosted mode: an endpoint ARN/name overrides Takara entirely, ignoring any
+  // explicit `model` override since the deployed endpoint is the only model available.
+  // Cached separately from the Takara singleton so the two never shadow each other.
+  const sageMaker = resolveSageMakerConfig();
+  if (sageMaker) {
+    if (!sageMakerBackend) {
+      const sageMakerModel = sageMakerModelId(sageMaker.endpointName);
+      sageMakerBackend = new OpenAIEmbeddingBackend({
+        model: sageMakerModel,
+        client: createSageMakerClient(sageMaker),
+        dimensions: resolveEmbeddingDimensions(sageMakerModel),
+      });
+    }
+    return sageMakerBackend;
+  }
+
   if (model) {
     return new OpenAIEmbeddingBackend({
       model,

--- a/src/embeddings/sagemaker.ts
+++ b/src/embeddings/sagemaker.ts
@@ -1,9 +1,14 @@
-import {
-  InvokeEndpointCommand,
-  type InvokeEndpointCommandOutput,
-  SageMakerRuntimeClient,
-} from "@aws-sdk/client-sagemaker-runtime";
 import type { EmbeddingClient, EmbeddingPayload, EmbeddingResponse } from "./openai.ts";
+
+type SageMakerRuntimeModule = typeof import("@aws-sdk/client-sagemaker-runtime");
+
+/** Lazily loaded so Takara-only MCP/CLI processes never pay the AWS SDK startup cost. */
+let sageMakerRuntimePromise: Promise<SageMakerRuntimeModule> | null = null;
+
+function loadSageMakerRuntime(): Promise<SageMakerRuntimeModule> {
+  sageMakerRuntimePromise ??= import("@aws-sdk/client-sagemaker-runtime");
+  return sageMakerRuntimePromise;
+}
 
 /** arn:aws:sagemaker:<region>:<account-id>:endpoint/<endpoint-name> (also covers aws-cn/aws-us-gov). */
 const ENDPOINT_ARN_PATTERN = /^arn:aws[a-z0-9-]*:sagemaker:([a-z0-9-]+):(\d{12}):endpoint\/(.+)$/;
@@ -192,7 +197,7 @@ function buildRequestBody(
 }
 
 export function createSageMakerClient(config: SageMakerEmbeddingConfig): EmbeddingClient {
-  const client = new SageMakerRuntimeClient({ region: config.region });
+  let client: InstanceType<SageMakerRuntimeModule["SageMakerRuntimeClient"]> | null = null;
 
   return {
     async createEmbeddings(
@@ -200,9 +205,12 @@ export function createSageMakerClient(config: SageMakerEmbeddingConfig): Embeddi
       _model: string,
       dimensions?: number,
     ): Promise<EmbeddingResponse> {
+      const { InvokeEndpointCommand, SageMakerRuntimeClient } = await loadSageMakerRuntime();
+      client ??= new SageMakerRuntimeClient({ region: config.region });
+
       const body = buildRequestBody(config, input, dimensions);
 
-      let response: InvokeEndpointCommandOutput;
+      let response: Awaited<ReturnType<typeof client.send>>;
       try {
         response = await client.send(
           new InvokeEndpointCommand({

--- a/src/embeddings/sagemaker.ts
+++ b/src/embeddings/sagemaker.ts
@@ -1,0 +1,259 @@
+import {
+  InvokeEndpointCommand,
+  type InvokeEndpointCommandOutput,
+  SageMakerRuntimeClient,
+} from "@aws-sdk/client-sagemaker-runtime";
+import type { EmbeddingClient, EmbeddingPayload, EmbeddingResponse } from "./openai.ts";
+
+/** arn:aws:sagemaker:<region>:<account-id>:endpoint/<endpoint-name> (also covers aws-cn/aws-us-gov). */
+const ENDPOINT_ARN_PATTERN = /^arn:aws[a-z0-9-]*:sagemaker:([a-z0-9-]+):(\d{12}):endpoint\/(.+)$/;
+
+export interface SageMakerEmbeddingConfig {
+  endpointName: string;
+  region: string;
+  normalize: boolean;
+  truncate: boolean;
+  truncationDirection: "Left" | "Right";
+  promptName?: string;
+}
+
+export function parseSageMakerEndpointArn(arn: string): {
+  region: string;
+  accountId: string;
+  endpointName: string;
+} {
+  const match = ENDPOINT_ARN_PATTERN.exec(arn.trim());
+  if (!match) {
+    throw new Error(
+      `Invalid SageMaker endpoint ARN: "${arn}". Expected format ` +
+        "arn:aws:sagemaker:<region>:<account-id>:endpoint/<endpoint-name>.",
+    );
+  }
+  const [, region, accountId, endpointName] = match;
+  if (!region || !accountId || !endpointName) {
+    throw new Error(`Invalid SageMaker endpoint ARN: "${arn}".`);
+  }
+  return { region, accountId, endpointName };
+}
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (!raw) {
+    return fallback;
+  }
+  return !["false", "0", "no"].includes(raw);
+}
+
+function resolveTruncationDirection(): "Left" | "Right" {
+  return process.env.MIRU_SAGEMAKER_TRUNCATION_DIRECTION?.trim() === "Left" ? "Left" : "Right";
+}
+
+/**
+ * Reads MIRU_SAGEMAKER_ENDPOINT_ARN (or MIRU_SAGEMAKER_ENDPOINT_NAME + a region) to enable
+ * self-hosted mode. AWS credentials are resolved by the SDK's default provider chain
+ * (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN, AWS_PROFILE, or an IAM role) —
+ * there is nothing Miru-specific to configure for auth.
+ */
+export function resolveSageMakerConfig(): SageMakerEmbeddingConfig | null {
+  const arn = process.env.MIRU_SAGEMAKER_ENDPOINT_ARN?.trim();
+  const explicitName = process.env.MIRU_SAGEMAKER_ENDPOINT_NAME?.trim();
+
+  let endpointName: string;
+  let region: string;
+
+  if (arn) {
+    const parsed = parseSageMakerEndpointArn(arn);
+    endpointName = parsed.endpointName;
+    region = parsed.region;
+  } else if (explicitName) {
+    endpointName = explicitName;
+    const explicitRegion =
+      process.env.MIRU_SAGEMAKER_REGION?.trim() ||
+      process.env.AWS_REGION?.trim() ||
+      process.env.AWS_DEFAULT_REGION?.trim();
+    if (!explicitRegion) {
+      throw new Error(
+        "MIRU_SAGEMAKER_ENDPOINT_NAME is set but no AWS region was found. Set " +
+          "MIRU_SAGEMAKER_REGION, AWS_REGION, or AWS_DEFAULT_REGION.",
+      );
+    }
+    region = explicitRegion;
+  } else {
+    return null;
+  }
+
+  return {
+    endpointName,
+    region,
+    normalize: envBool("MIRU_SAGEMAKER_NORMALIZE", true),
+    truncate: envBool("MIRU_SAGEMAKER_TRUNCATE", true),
+    truncationDirection: resolveTruncationDirection(),
+    promptName: process.env.MIRU_SAGEMAKER_PROMPT_NAME?.trim() || undefined,
+  };
+}
+
+export function isSageMakerConfigured(): boolean {
+  return resolveSageMakerConfig() != null;
+}
+
+/** Shown for credential/permission failures — mirrors EMBEDDING_AUTH_ERROR_MESSAGE for the AWS path. */
+export const SAGEMAKER_AUTH_ERROR_MESSAGE =
+  "Not authorized to invoke this SageMaker endpoint. Check your AWS credentials " +
+  "(AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN or AWS_PROFILE) and that the " +
+  "identity has sagemaker:InvokeEndpoint permission on the endpoint.";
+
+const AUTH_EXCEPTION_NAMES = new Set([
+  "AccessDeniedException",
+  "UnrecognizedClientException",
+  "ExpiredTokenException",
+  "CredentialsProviderError",
+]);
+
+class SageMakerInvokeError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "SageMakerInvokeError";
+    this.status = status;
+  }
+}
+
+function toInvokeError(err: unknown): SageMakerInvokeError {
+  const awsErr = err as {
+    name?: string;
+    message?: string;
+    $metadata?: { httpStatusCode?: number };
+    OriginalStatusCode?: string | number;
+    OriginalMessage?: string;
+  };
+
+  if (awsErr?.name && AUTH_EXCEPTION_NAMES.has(awsErr.name)) {
+    return new SageMakerInvokeError(403, SAGEMAKER_AUTH_ERROR_MESSAGE);
+  }
+
+  // ModelError wraps the embedding container's real status/message (e.g. 424 when the
+  // deployed model isn't an embedding model) behind SageMaker's own 424 response.
+  const originalStatus =
+    awsErr?.OriginalStatusCode != null ? Number(awsErr.OriginalStatusCode) : undefined;
+  const status =
+    originalStatus != null && Number.isFinite(originalStatus)
+      ? originalStatus
+      : (awsErr?.$metadata?.httpStatusCode ?? 500);
+  const message = awsErr?.OriginalMessage ?? awsErr?.message ?? String(err);
+
+  if (status === 424) {
+    return new SageMakerInvokeError(
+      424,
+      `SageMaker endpoint returned 424 — the deployed model is not an embedding model (${message}).`,
+    );
+  }
+  return new SageMakerInvokeError(status, `SageMaker endpoint error ${status}: ${message}`);
+}
+
+function extractEmbeddings(parsed: unknown): EmbeddingPayload[] {
+  if (Array.isArray(parsed)) {
+    return parsed as EmbeddingPayload[];
+  }
+  if (parsed && typeof parsed === "object") {
+    const obj = parsed as {
+      embeddings?: EmbeddingPayload[];
+      data?: Array<{ embedding: EmbeddingPayload }>;
+    };
+    if (Array.isArray(obj.embeddings)) {
+      return obj.embeddings;
+    }
+    if (Array.isArray(obj.data)) {
+      return obj.data.map((item) => item.embedding);
+    }
+  }
+  throw new Error("SageMaker endpoint returned an unrecognized embedding payload shape");
+}
+
+/** Builds the TEI-style /embed request body this schema expects (`inputs`, not `input`). */
+function buildRequestBody(
+  config: SageMakerEmbeddingConfig,
+  input: string[] | string,
+  dimensions?: number,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    inputs: input,
+    normalize: config.normalize,
+    truncate: config.truncate,
+    truncation_direction: config.truncationDirection,
+  };
+  if (dimensions != null) {
+    body.dimensions = dimensions;
+  }
+  if (config.promptName) {
+    body.prompt_name = config.promptName;
+  }
+  return body;
+}
+
+export function createSageMakerClient(config: SageMakerEmbeddingConfig): EmbeddingClient {
+  const client = new SageMakerRuntimeClient({ region: config.region });
+
+  return {
+    async createEmbeddings(
+      input: string[] | string,
+      _model: string,
+      dimensions?: number,
+    ): Promise<EmbeddingResponse> {
+      const body = buildRequestBody(config, input, dimensions);
+
+      let response: InvokeEndpointCommandOutput;
+      try {
+        response = await client.send(
+          new InvokeEndpointCommand({
+            EndpointName: config.endpointName,
+            ContentType: "application/json",
+            Accept: "application/json",
+            Body: new TextEncoder().encode(JSON.stringify(body)),
+          }),
+        );
+      } catch (err) {
+        throw toInvokeError(err);
+      }
+
+      if (!response.Body) {
+        throw new Error("SageMaker endpoint returned an empty response body");
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(new TextDecoder().decode(response.Body));
+      } catch {
+        throw new Error("SageMaker endpoint returned invalid JSON");
+      }
+
+      const embeddings = extractEmbeddings(parsed);
+      return { data: embeddings.map((embedding, index) => ({ index, embedding })) };
+    },
+  };
+}
+
+export interface ValidateSageMakerResult {
+  valid: boolean;
+  status?: number;
+  message: string;
+}
+
+/** Real InvokeEndpoint round trip, used by `miru setup --sagemaker` to confirm auth + shape. */
+export async function validateSageMakerConnection(
+  config: SageMakerEmbeddingConfig,
+): Promise<ValidateSageMakerResult> {
+  try {
+    const client = createSageMakerClient(config);
+    const response = await client.createEmbeddings("miru setup validation", "sagemaker-setup");
+    const embedding = response.data[0]?.embedding;
+    if (!embedding) {
+      return { valid: false, message: "SageMaker endpoint returned an empty response." };
+    }
+    return { valid: true, message: "SageMaker endpoint responded successfully." };
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    const message = err instanceof Error ? err.message : String(err);
+    return { valid: false, status, message };
+  }
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -83,7 +83,9 @@ export function printEnvHelp(): void {
   writeStdout("  AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN / AWS_PROFILE");
   writeStdout("      Standard AWS credential resolution — nothing Miru-specific to set");
   writeStdout("");
+  hint("Enterprise self-hosted setup: docs/self-hosted-sagemaker.md");
   hint("Run `miru setup --sagemaker --arn <arn> --aws-profile <name>` to store this.");
+  hint("Setup confirms auth, saves SageMaker config, and removes any stored Takara API key.");
   writeStdout("");
 }
 
@@ -157,9 +159,12 @@ export function printCommandHelp(command: string): void {
       writeStdout("  --arn ARN           Endpoint ARN (implies --sagemaker)");
       writeStdout("  --aws-profile NAME  AWS profile to inherit credentials from");
       writeStdout("");
-      hint("Miru only inherits AWS credentials — it never creates or writes AWS config.");
-      hint("Set up the profile yourself first, e.g. `aws configure --profile miru`,");
-      hint("then point --aws-profile at it. Requires both --arn and --aws-profile.");
+      hint("Switching modes: see docs/self-hosted-sagemaker.md.");
+      hint("Takara and SageMaker are mutually exclusive — setup for one removes the other.");
+      hint("SageMaker setup invokes the endpoint once (auth + embedding check), then saves.");
+      hint("Miru only inherits AWS credentials — it never creates or writes ~/.aws.");
+      hint("Example: aws configure --profile miru");
+      hint("         miru setup --sagemaker --arn <arn> --aws-profile miru");
       writeStdout("");
       return;
     case "install":

--- a/src/help.ts
+++ b/src/help.ts
@@ -84,7 +84,8 @@ export function printEnvHelp(): void {
   writeStdout("      Standard AWS credential resolution — nothing Miru-specific to set");
   writeStdout("");
   hint("Enterprise self-hosted setup: docs/self-hosted-sagemaker.md");
-  hint("Run `miru setup --sagemaker --arn <arn> --aws-profile <name>` to store this.");
+  hint("Admin runbook: bun run sagemaker:create-invoke-user -- --endpoint-arn <arn>");
+  hint("Then: miru setup --sagemaker --arn <arn> --profile <name>");
   hint("Setup confirms auth, saves SageMaker config, and removes any stored Takara API key.");
   writeStdout("");
 }
@@ -149,7 +150,7 @@ export function printCommandHelp(command: string): void {
       commandHeader("setup", "Store and validate Takara or self-hosted SageMaker credentials.");
       section("Usage");
       writeStdout("  miru setup [--key TOKEN] [--force] [--clear]");
-      writeStdout("  miru setup --sagemaker --arn ENDPOINT_ARN --aws-profile NAME");
+      writeStdout("  miru setup --sagemaker --arn ENDPOINT_ARN --profile NAME");
       section("Options (Takara)");
       writeStdout("  --key, -k TOKEN     Non-interactive key entry");
       writeStdout("  --force             Replace an existing stored key");
@@ -157,14 +158,14 @@ export function printCommandHelp(command: string): void {
       section("Options (SageMaker)");
       writeStdout("  --sagemaker         Switch setup to self-hosted SageMaker mode");
       writeStdout("  --arn ARN           Endpoint ARN (implies --sagemaker)");
-      writeStdout("  --aws-profile NAME  AWS profile to inherit credentials from");
+      writeStdout("  --profile NAME       AWS profile to inherit credentials from");
       writeStdout("");
-      hint("Switching modes: see docs/self-hosted-sagemaker.md.");
+      hint("Enterprise guide: docs/self-hosted-sagemaker.md (Marketplace + invoke-user runbook).");
       hint("Takara and SageMaker are mutually exclusive — setup for one removes the other.");
       hint("SageMaker setup invokes the endpoint once (auth + embedding check), then saves.");
-      hint("Miru only inherits AWS credentials — it never creates or writes ~/.aws.");
-      hint("Example: aws configure --profile miru");
-      hint("         miru setup --sagemaker --arn <arn> --aws-profile miru");
+      hint("Miru only inherits AWS credentials — it never creates IAM users or writes ~/.aws.");
+      hint("Admin runbook (repo): bun run sagemaker:create-invoke-user -- --endpoint-arn <arn>");
+      hint("Then: miru setup --sagemaker --arn <arn> --profile miru");
       writeStdout("");
       return;
     case "install":

--- a/src/help.ts
+++ b/src/help.ts
@@ -67,6 +67,24 @@ export function printEnvHelp(): void {
   writeStdout("  MIRU_TOKENIZER_JSON");
   writeStdout("      Path to tokenizer.json (default: <package>/tokenizer/tokenizer.json)");
   writeStdout("");
+  section("Self-hosted (AWS SageMaker)");
+  writeStdout("  MIRU_SAGEMAKER_ENDPOINT_ARN");
+  writeStdout("      arn:aws:sagemaker:<region>:<account-id>:endpoint/<name> — set this to");
+  writeStdout("      bypass Takara entirely and embed via your own SageMaker endpoint.");
+  writeStdout("  MIRU_SAGEMAKER_ENDPOINT_NAME / MIRU_SAGEMAKER_REGION");
+  writeStdout("      Alternative to the ARN when you'd rather name the endpoint + region");
+  writeStdout("      directly (falls back to AWS_REGION / AWS_DEFAULT_REGION).");
+  writeStdout("  MIRU_SAGEMAKER_NORMALIZE / MIRU_SAGEMAKER_TRUNCATE");
+  writeStdout("      Default: true");
+  writeStdout("  MIRU_SAGEMAKER_TRUNCATION_DIRECTION");
+  writeStdout('      "Left" | "Right" (default: Right)');
+  writeStdout("  MIRU_SAGEMAKER_PROMPT_NAME");
+  writeStdout("      Optional prompt_name passed to the endpoint");
+  writeStdout("  AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN / AWS_PROFILE");
+  writeStdout("      Standard AWS credential resolution — nothing Miru-specific to set");
+  writeStdout("");
+  hint("Run `miru setup --sagemaker --arn <arn> --aws-profile <name>` to store this.");
+  writeStdout("");
 }
 
 export function printFullHelp(): void {
@@ -126,13 +144,22 @@ export function printCommandHelp(command: string): void {
       writeStdout("");
       return;
     case "setup":
-      commandHeader("setup", "Store and validate your Takara API key.");
+      commandHeader("setup", "Store and validate Takara or self-hosted SageMaker credentials.");
       section("Usage");
       writeStdout("  miru setup [--key TOKEN] [--force] [--clear]");
-      section("Options");
+      writeStdout("  miru setup --sagemaker --arn ENDPOINT_ARN --aws-profile NAME");
+      section("Options (Takara)");
       writeStdout("  --key, -k TOKEN     Non-interactive key entry");
       writeStdout("  --force             Replace an existing stored key");
       writeStdout("  --clear             Remove stored credentials");
+      section("Options (SageMaker)");
+      writeStdout("  --sagemaker         Switch setup to self-hosted SageMaker mode");
+      writeStdout("  --arn ARN           Endpoint ARN (implies --sagemaker)");
+      writeStdout("  --aws-profile NAME  AWS profile to inherit credentials from");
+      writeStdout("");
+      hint("Miru only inherits AWS credentials — it never creates or writes AWS config.");
+      hint("Set up the profile yourself first, e.g. `aws configure --profile miru`,");
+      hint("then point --aws-profile at it. Requires both --arn and --aws-profile.");
       writeStdout("");
       return;
     case "install":

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,4 +1,5 @@
 import { stdin as input, stdout as output } from "node:process";
+import * as readline from "node:readline/promises";
 
 export interface HiddenPromptState {
   value: string;
@@ -58,6 +59,18 @@ export function applyHiddenPromptChar(
     state: { ...state, value: state.value + char },
     echo: "*",
   };
+}
+
+/** Visible-input prompt (not for secrets — use promptHidden for those). */
+export async function promptText(message: string, defaultValue = ""): Promise<string> {
+  const rl = readline.createInterface({ input, output });
+  try {
+    const suffix = defaultValue ? ` (${defaultValue})` : "";
+    const answer = (await rl.question(`${message}${suffix}: `)).trim();
+    return answer || defaultValue;
+  } finally {
+    rl.close();
+  }
 }
 
 export async function promptHidden(message: string): Promise<string> {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -4,11 +4,19 @@ import {
   loadStoredCredentials,
   readStoredCredentials,
   resolveCredentialsPath,
+  type StoredSageMakerCredentials,
   saveStoredCredentials,
+  saveStoredSageMakerCredentials,
 } from "./credentials.ts";
+import {
+  isSageMakerConfigured,
+  parseSageMakerEndpointArn,
+  type SageMakerEmbeddingConfig,
+  validateSageMakerConnection,
+} from "./embeddings/sagemaker.ts";
 import { validateEmbeddingApiKey } from "./embeddings/validate.ts";
 import { hasTakaraApiKeyInEnv, resolveEmbeddingApiKey } from "./env.ts";
-import { promptHidden } from "./prompt.ts";
+import { promptHidden, promptText } from "./prompt.ts";
 import { Spinner } from "./spinner.ts";
 
 async function promptApiKey(): Promise<string> {
@@ -26,6 +34,9 @@ export interface RunSetupOptions {
   apiKey?: string;
   force?: boolean;
   skipValidation?: boolean;
+  sagemaker?: boolean;
+  sagemakerArn?: string;
+  awsProfile?: string;
 }
 
 export interface RunSetupResult {
@@ -33,7 +44,97 @@ export interface RunSetupResult {
   newlySaved: boolean;
 }
 
+async function promptSageMakerArn(): Promise<string> {
+  while (true) {
+    const arn = await promptText("SageMaker endpoint ARN");
+    if (!arn) {
+      fail("Endpoint ARN cannot be empty.");
+      continue;
+    }
+    try {
+      parseSageMakerEndpointArn(arn);
+      return arn;
+    } catch (err) {
+      fail(err instanceof Error ? err.message : String(err));
+    }
+  }
+}
+
+async function promptAwsProfile(): Promise<string> {
+  while (true) {
+    const profile = await promptText(
+      "AWS profile name (must already exist in ~/.aws)",
+      process.env.AWS_PROFILE || "miru",
+    );
+    if (profile) {
+      return profile;
+    }
+    fail("AWS profile name cannot be empty.");
+  }
+}
+
+/**
+ * Miru only ever inherits AWS credentials — it never creates, writes, or rotates an
+ * AWS profile. Set one up yourself first (e.g. `aws configure --profile miru`).
+ */
+export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<RunSetupResult> {
+  writeStderr("");
+  printBrandBanner(process.stderr);
+  divider("─", 48, process.stderr);
+  writeStderr("Miru will connect directly to your self-hosted SageMaker embedding endpoint.");
+  hint("Miru only inherits AWS credentials from a profile you've already configured —");
+  hint("it never creates or writes to ~/.aws. Run `aws configure --profile <name>` first.");
+  writeStderr("");
+
+  const arnInput = options.sagemakerArn ?? (await promptSageMakerArn());
+  const parsed = parseSageMakerEndpointArn(arnInput);
+
+  let profile = options.awsProfile;
+  if (!profile) {
+    if (!canPromptForCredentials()) {
+      throw new Error(
+        "An AWS profile name is required. Pass --aws-profile <name>, or run " +
+          "`miru setup --sagemaker` interactively.",
+      );
+    }
+    profile = await promptAwsProfile();
+  }
+
+  process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = arnInput;
+  process.env.AWS_PROFILE = profile;
+
+  if (!options.skipValidation) {
+    const spinner = new Spinner(`Validating SageMaker endpoint (profile "${profile}")`);
+    spinner.start();
+    const config: SageMakerEmbeddingConfig = {
+      endpointName: parsed.endpointName,
+      region: parsed.region,
+      normalize: true,
+      truncate: true,
+      truncationDirection: "Right",
+    };
+    const result = await validateSageMakerConnection(config);
+    if (!result.valid) {
+      spinner.stop();
+      throw new Error(result.message);
+    }
+    spinner.succeed("SageMaker endpoint validated");
+  }
+
+  const stored: StoredSageMakerCredentials = { endpoint_arn: arnInput, profile };
+  const path = await saveStoredSageMakerCredentials(stored);
+  writeStderr("");
+  success(`Saved SageMaker config to ${path}`);
+  hint("Miru will use this endpoint instead of Takara from now on.");
+  writeStderr("");
+  return { path, newlySaved: true };
+}
+
 export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupResult> {
+  if (options.sagemaker || options.sagemakerArn) {
+    return runSageMakerSetup(options);
+  }
+
   if (!options.force && hasTakaraApiKeyInEnv()) {
     const path = resolveCredentialsPath();
     const stored = await readStoredCredentials();
@@ -98,6 +199,9 @@ export function canPromptForCredentials(): boolean {
 }
 
 export function hasCredentials(): boolean {
+  if (isSageMakerConfigured()) {
+    return true;
+  }
   try {
     resolveEmbeddingApiKey();
     return true;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -44,6 +44,68 @@ export interface RunSetupResult {
   newlySaved: boolean;
 }
 
+export interface ParsedSetupCliArgs {
+  apiKey?: string;
+  force: boolean;
+  clear: boolean;
+  sagemaker: boolean;
+  sagemakerArn?: string;
+  profile?: string;
+}
+
+export type SetupCliArgError = "clear_with_key" | "sagemaker_with_key";
+
+/** Parse `miru setup` argv (everything after the `setup` command). */
+export function parseSetupCliArgs(rest: string[]): {
+  args: ParsedSetupCliArgs;
+  error?: SetupCliArgError;
+} {
+  let apiKey: string | undefined;
+  let force = false;
+  let clear = false;
+  let sagemaker = false;
+  let sagemakerArn: string | undefined;
+  let profile: string | undefined;
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--force") {
+      force = true;
+    } else if (arg === "--clear") {
+      clear = true;
+    } else if ((arg === "--key" || arg === "-k") && rest[i + 1]) {
+      apiKey = rest[++i];
+    } else if (arg === "--sagemaker") {
+      sagemaker = true;
+    } else if (arg === "--arn" && rest[i + 1]) {
+      sagemakerArn = rest[++i];
+    } else if (arg === "--profile" && rest[i + 1]) {
+      profile = rest[++i];
+    }
+  }
+
+  if (sagemakerArn) {
+    sagemaker = true;
+  }
+
+  const args: ParsedSetupCliArgs = {
+    apiKey,
+    force,
+    clear,
+    sagemaker,
+    sagemakerArn,
+    profile,
+  };
+
+  if (clear && apiKey) {
+    return { args, error: "clear_with_key" };
+  }
+  if (sagemaker && apiKey) {
+    return { args, error: "sagemaker_with_key" };
+  }
+  return { args };
+}
+
 async function promptSageMakerArn(): Promise<string> {
   while (true) {
     const arn = await promptText("SageMaker endpoint ARN");

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -36,7 +36,7 @@ export interface RunSetupOptions {
   skipValidation?: boolean;
   sagemaker?: boolean;
   sagemakerArn?: string;
-  awsProfile?: string;
+  profile?: string;
 }
 
 export interface RunSetupResult {
@@ -90,11 +90,11 @@ export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<
   const arnInput = options.sagemakerArn ?? (await promptSageMakerArn());
   const parsed = parseSageMakerEndpointArn(arnInput);
 
-  let profile = options.awsProfile;
+  let profile = options.profile;
   if (!profile) {
     if (!canPromptForCredentials()) {
       throw new Error(
-        "An AWS profile name is required. Pass --aws-profile <name>, or run " +
+        "An AWS profile name is required. Pass --profile <name>, or run " +
           "`miru setup --sagemaker` interactively.",
       );
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -167,7 +167,9 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
   divider("─", 48, process.stderr);
   writeStdout("Miru needs a Takara API key for code embeddings.");
   hint("Get a bearer token from Takara, then enter it below.");
-  hint("This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.");
+  hint(
+    "This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.",
+  );
   writeStdout("");
 
   const apiKey = options.apiKey ?? (await promptApiKey());

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,4 +1,4 @@
-import { divider, fail, hint, info, printBrandBanner, success, writeStderr } from "./cli-ui.ts";
+import { divider, fail, hint, info, printBrandBanner, success, writeStdout } from "./cli-ui.ts";
 import {
   clearStoredCredentials,
   loadStoredCredentials,
@@ -78,13 +78,14 @@ async function promptAwsProfile(): Promise<string> {
  * AWS profile. Set one up yourself first (e.g. `aws configure --profile miru`).
  */
 export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<RunSetupResult> {
-  writeStderr("");
+  writeStdout("");
   printBrandBanner(process.stderr);
   divider("─", 48, process.stderr);
-  writeStderr("Miru will connect directly to your self-hosted SageMaker embedding endpoint.");
+  writeStdout("Miru will connect directly to your self-hosted SageMaker embedding endpoint.");
   hint("Miru only inherits AWS credentials from a profile you've already configured —");
   hint("it never creates or writes to ~/.aws. Run `aws configure --profile <name>` first.");
-  writeStderr("");
+  hint("This replaces any stored Takara API key — only one embedding mode is active at a time.");
+  writeStdout("");
 
   const arnInput = options.sagemakerArn ?? (await promptSageMakerArn());
   const parsed = parseSageMakerEndpointArn(arnInput);
@@ -122,11 +123,16 @@ export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<
   }
 
   const stored: StoredSageMakerCredentials = { endpoint_arn: arnInput, profile };
+  const hadTakaraKey = Boolean((await readStoredCredentials())?.takara_api_key);
   const path = await saveStoredSageMakerCredentials(stored);
-  writeStderr("");
+  writeStdout("");
   success(`Saved SageMaker config to ${path}`);
-  hint("Miru will use this endpoint instead of Takara from now on.");
-  writeStderr("");
+  if (hadTakaraKey) {
+    hint("Removed the stored Takara API key — Miru now embeds only via SageMaker.");
+  } else {
+    hint("Miru will embed via this SageMaker endpoint (Takara is not used).");
+  }
+  writeStdout("");
   return { path, newlySaved: true };
 }
 
@@ -148,20 +154,21 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
 
   if (!options.force) {
     const stored = await readStoredCredentials();
-    if (stored && !options.apiKey) {
+    if (stored?.takara_api_key && !options.apiKey) {
       info(`API key already stored at ${resolveCredentialsPath()}. Use --force to replace.`);
       process.env.TAKARA_API_KEY = stored.takara_api_key;
       return { path: resolveCredentialsPath(), newlySaved: false };
     }
   }
 
-  writeStderr("");
+  writeStdout("");
   // stderr banner: setup runs before stdout may be a TTY (e.g. piped miru search).
   printBrandBanner(process.stderr);
   divider("─", 48, process.stderr);
-  writeStderr("Miru needs a Takara API key for code embeddings.");
+  writeStdout("Miru needs a Takara API key for code embeddings.");
   hint("Get a bearer token from Takara, then enter it below.");
-  writeStderr("");
+  hint("This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.");
+  writeStdout("");
 
   const apiKey = options.apiKey ?? (await promptApiKey());
 
@@ -176,22 +183,27 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
     spinner.succeed("API key validated");
   }
 
+  const hadSageMaker = Boolean((await readStoredCredentials())?.sagemaker);
   const path = await saveStoredCredentials(apiKey);
   process.env.TAKARA_API_KEY = apiKey;
-  writeStderr("");
+  writeStdout("");
   success(`Saved credentials to ${path}`);
-  hint("MCP loads this key from credentials.json automatically.");
-  writeStderr("");
+  if (hadSageMaker) {
+    hint("Removed the stored SageMaker endpoint — Miru now embeds only via Takara.");
+  } else {
+    hint("MCP loads this key from credentials.json automatically.");
+  }
+  writeStdout("");
   return { path, newlySaved: true };
 }
 
 export async function runClearCredentials(): Promise<void> {
   const { cleared, path } = await clearStoredCredentials();
   if (cleared) {
-    success(`Removed stored API key from ${path}`);
+    success(`Removed stored credentials from ${path}`);
     return;
   }
-  info(`No stored API key at ${path}`);
+  info(`No stored credentials at ${path}`);
 }
 
 export function canPromptForCredentials(): boolean {
@@ -226,7 +238,7 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
 
   const wantsPrompt = options?.interactive ?? true;
   if (wantsPrompt && canPromptForCredentials()) {
-    writeStderr("");
+    writeStdout("");
     info("No Takara API key found.");
     hint("Miru needs one for embeddings — enter it below (same as `miru setup`).");
     await runSetup();
@@ -234,10 +246,10 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
     return;
   }
 
-  writeStderr("");
+  writeStdout("");
   // Brand on stderr when credentials are missing in non-interactive mode (stdout may not be a TTY).
   printBrandBanner(process.stderr);
-  writeStderr("");
+  writeStdout("");
 
   throw new Error(
     "Takara API key required. Run `miru setup` in a terminal, or set TAKARA_API_KEY " +

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -9,6 +9,7 @@ import {
   resolveCredentialsDir,
   resolveMiruStateDir,
   saveStoredCredentials,
+  saveStoredSageMakerCredentials,
 } from "../src/credentials.ts";
 import { TAKARA_API_KEY_ENV } from "../src/env.ts";
 
@@ -28,13 +29,22 @@ function clearTakaraApiKey(): void {
   delete process.env[TAKARA_API_KEY_ENV];
 }
 
+function clearSageMakerEnv(): void {
+  delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+  delete process.env.AWS_PROFILE;
+}
+
 describe("credentials", () => {
   let credDir: string;
   const prevDir = process.env.MIRU_CREDENTIALS_DIR;
   let takaraApiKeySnapshot: string | undefined;
+  let sageMakerArnSnapshot: string | undefined;
+  let awsProfileSnapshot: string | undefined;
 
   beforeEach(() => {
     takaraApiKeySnapshot = snapshotTakaraApiKey();
+    sageMakerArnSnapshot = process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    awsProfileSnapshot = process.env.AWS_PROFILE;
   });
 
   afterEach(async () => {
@@ -47,6 +57,16 @@ describe("credentials", () => {
       process.env.MIRU_CREDENTIALS_DIR = prevDir;
     }
     restoreTakaraApiKey(takaraApiKeySnapshot);
+    if (sageMakerArnSnapshot === undefined) {
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    } else {
+      process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = sageMakerArnSnapshot;
+    }
+    if (awsProfileSnapshot === undefined) {
+      delete process.env.AWS_PROFILE;
+    } else {
+      process.env.AWS_PROFILE = awsProfileSnapshot;
+    }
   });
 
   test("saveStoredCredentials writes versioned file with restricted mode", async () => {
@@ -156,5 +176,43 @@ describe("credentials", () => {
     const result = await clearStoredCredentials();
     expect(result.cleared).toBe(true);
     expect(process.env.TAKARA_API_KEY).toBe("env-token");
+  });
+
+  test("saving SageMaker credentials removes stored Takara API key", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    clearTakaraApiKey();
+    clearSageMakerEnv();
+
+    await saveStoredCredentials("takara-token");
+    process.env.TAKARA_API_KEY = "takara-token";
+
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
+
+    const stored = await readStoredCredentials();
+    expect(stored?.takara_api_key).toBeUndefined();
+    expect(stored?.sagemaker).toEqual({ endpoint_arn: arn, profile: "miru" });
+    expect(process.env.TAKARA_API_KEY).toBeUndefined();
+  });
+
+  test("saving Takara credentials removes stored SageMaker endpoint", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-cred-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    clearTakaraApiKey();
+    clearSageMakerEnv();
+
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = arn;
+    process.env.AWS_PROFILE = "miru";
+
+    await saveStoredCredentials("takara-token");
+
+    const stored = await readStoredCredentials();
+    expect(stored?.sagemaker).toBeUndefined();
+    expect(stored?.takara_api_key).toBe("takara-token");
+    expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBeUndefined();
+    expect(process.env.AWS_PROFILE).toBeUndefined();
   });
 });

--- a/tests/sagemaker-lazy-load.test.ts
+++ b/tests/sagemaker-lazy-load.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function runProbe(source: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn({
+    cmd: ["bun", "-e", source],
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      MIRU_SAGEMAKER_ENDPOINT_ARN: "",
+      MIRU_SAGEMAKER_ENDPOINT_NAME: "",
+    },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+const AWS_SDK_PROBE = `
+const { createRequire } = await import("node:module");
+const require = createRequire(import.meta.url);
+const id = require.resolve("@aws-sdk/client-sagemaker-runtime");
+console.log(require.cache[id] ? "AWS_SDK=loaded" : "AWS_SDK=absent");
+`;
+
+describe("SageMaker AWS SDK lazy load", () => {
+  test("importing openai/sagemaker helpers does not load the AWS SDK", async () => {
+    const { stdout, stderr, exitCode } = await runProbe(`
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_NAME;
+      // MCP/CLI import graph: openai pulls sagemaker helpers. Neither should load AWS SDK.
+      const { resolveEmbeddingModel } = await import("./src/embeddings/openai.ts");
+      const {
+        parseSageMakerEndpointArn,
+        resolveSageMakerConfig,
+        createSageMakerClient,
+        isSageMakerConfigured,
+      } = await import("./src/embeddings/sagemaker.ts");
+
+      parseSageMakerEndpointArn("arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test");
+      if (resolveSageMakerConfig() != null) throw new Error("expected null config");
+      if (isSageMakerConfigured()) throw new Error("expected false");
+      // Building the client wrapper must stay free of the AWS SDK.
+      createSageMakerClient({
+        endpointName: "miru-test",
+        region: "us-east-1",
+        normalize: true,
+        truncate: true,
+        truncationDirection: "Right",
+      });
+      resolveEmbeddingModel();
+      ${AWS_SDK_PROBE}
+    `);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("AWS_SDK=absent");
+  });
+
+  test("invoking the SageMaker client loads the AWS SDK", async () => {
+    const { stdout, stderr, exitCode } = await runProbe(`
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_NAME;
+      const { createSageMakerClient } = await import("./src/embeddings/sagemaker.ts");
+      const client = createSageMakerClient({
+        endpointName: "miru-test",
+        region: "us-east-1",
+        normalize: true,
+        truncate: true,
+        truncationDirection: "Right",
+      });
+      try {
+        await client.createEmbeddings("lazy-load probe", "sagemaker:miru-test");
+      } catch {
+        // Invoke may fail without real AWS creds/endpoint; import is what matters.
+      }
+      ${AWS_SDK_PROBE}
+    `);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("AWS_SDK=loaded");
+  });
+});

--- a/tests/sagemaker-lazy-load.test.ts
+++ b/tests/sagemaker-lazy-load.test.ts
@@ -4,7 +4,9 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-async function runProbe(source: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function runProbe(
+  source: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const proc = Bun.spawn({
     cmd: ["bun", "-e", source],
     cwd: repoRoot,

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -2,12 +2,18 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { saveStoredCredentials } from "../src/credentials.ts";
+import {
+  readStoredCredentials,
+  saveStoredCredentials,
+  saveStoredSageMakerCredentials,
+} from "../src/credentials.ts";
 import { TAKARA_API_KEY_ENV } from "../src/env.ts";
 import {
   canPromptForCredentials,
   ensureCredentials,
   hasCredentials,
+  parseSetupCliArgs,
+  runSageMakerSetup,
   runSetup,
 } from "../src/setup.ts";
 
@@ -26,14 +32,30 @@ function restoreKey(value: string | undefined): void {
 describe("setup credentials", () => {
   let credDir = "";
   let keySnapshot: string | undefined;
+  let sageMakerArnSnapshot: string | undefined;
+  let awsProfileSnapshot: string | undefined;
 
   beforeEach(() => {
     keySnapshot = snapshotKey();
+    sageMakerArnSnapshot = process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    awsProfileSnapshot = process.env.AWS_PROFILE;
     delete process.env[TAKARA_API_KEY_ENV];
+    delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    delete process.env.AWS_PROFILE;
   });
 
   afterEach(async () => {
     restoreKey(keySnapshot);
+    if (sageMakerArnSnapshot === undefined) {
+      delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    } else {
+      process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = sageMakerArnSnapshot;
+    }
+    if (awsProfileSnapshot === undefined) {
+      delete process.env.AWS_PROFILE;
+    } else {
+      process.env.AWS_PROFILE = awsProfileSnapshot;
+    }
     if (credDir) {
       await rm(credDir, { recursive: true, force: true });
       credDir = "";
@@ -93,5 +115,115 @@ describe("setup credentials", () => {
     const result = await runSetup({ skipValidation: true });
     expect(result.newlySaved).toBe(false);
     expect(result.path).toContain("credentials.json");
+  });
+
+  test("runSageMakerSetup purges a stored Takara API key", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-sm-purge-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+    delete process.env.AWS_PROFILE;
+    await saveStoredCredentials("takara-token");
+    process.env.TAKARA_API_KEY = "takara-token";
+
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    const result = await runSageMakerSetup({
+      skipValidation: true,
+      sagemakerArn: arn,
+      profile: "miru",
+    });
+
+    expect(result.newlySaved).toBe(true);
+    const stored = await readStoredCredentials();
+    expect(stored?.takara_api_key).toBeUndefined();
+    expect(stored?.sagemaker).toEqual({ endpoint_arn: arn, profile: "miru" });
+    expect(process.env.TAKARA_API_KEY).toBeUndefined();
+    expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBe(arn);
+  });
+
+  test("runSetup purges a stored SageMaker endpoint", async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-setup-tk-purge-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    await saveStoredSageMakerCredentials({ endpoint_arn: arn, profile: "miru" });
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN = arn;
+    process.env.AWS_PROFILE = "miru";
+    delete process.env.TAKARA_API_KEY;
+
+    const result = await runSetup({
+      skipValidation: true,
+      apiKey: "new-takara-token",
+      force: true,
+    });
+
+    expect(result.newlySaved).toBe(true);
+    const stored = await readStoredCredentials();
+    expect(stored?.sagemaker).toBeUndefined();
+    expect(stored?.takara_api_key).toBe("new-takara-token");
+    expect(process.env.MIRU_SAGEMAKER_ENDPOINT_ARN).toBeUndefined();
+    expect(process.env.AWS_PROFILE).toBeUndefined();
+  });
+
+  test("hasCredentials is true when SageMaker endpoint ARN is configured", () => {
+    process.env.MIRU_SAGEMAKER_ENDPOINT_ARN =
+      "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    expect(hasCredentials()).toBe(true);
+    delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
+  });
+});
+
+describe("parseSetupCliArgs", () => {
+  test("parses Takara --key / -k and --force", () => {
+    expect(parseSetupCliArgs(["--key", "tok", "--force"]).args).toEqual({
+      apiKey: "tok",
+      force: true,
+      clear: false,
+      sagemaker: false,
+      sagemakerArn: undefined,
+      profile: undefined,
+    });
+    expect(parseSetupCliArgs(["-k", "tok"]).args.apiKey).toBe("tok");
+  });
+
+  test("parses SageMaker flags and implies sagemaker from --arn", () => {
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    expect(parseSetupCliArgs(["--sagemaker", "--arn", arn, "--profile", "miru"]).args).toEqual({
+      apiKey: undefined,
+      force: false,
+      clear: false,
+      sagemaker: true,
+      sagemakerArn: arn,
+      profile: "miru",
+    });
+    expect(parseSetupCliArgs(["--arn", arn]).args).toMatchObject({
+      sagemaker: true,
+      sagemakerArn: arn,
+    });
+  });
+
+  test("rejects combining --sagemaker with --key", () => {
+    const result = parseSetupCliArgs(["--sagemaker", "--key", "tok"]);
+    expect(result.error).toBe("sagemaker_with_key");
+    expect(result.args.sagemaker).toBe(true);
+    expect(result.args.apiKey).toBe("tok");
+  });
+
+  test("rejects combining --arn with --key", () => {
+    const arn = "arn:aws:sagemaker:us-east-1:123456789012:endpoint/miru-test";
+    expect(parseSetupCliArgs(["--arn", arn, "--key", "tok"]).error).toBe("sagemaker_with_key");
+  });
+
+  test("rejects combining --clear with --key", () => {
+    expect(parseSetupCliArgs(["--clear", "--key", "tok"]).error).toBe("clear_with_key");
+  });
+
+  test("parses --clear alone", () => {
+    expect(parseSetupCliArgs(["--clear"]).args).toEqual({
+      apiKey: undefined,
+      force: false,
+      clear: true,
+      sagemaker: false,
+      sagemakerArn: undefined,
+      profile: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add SageMaker `InvokeEndpoint` embedding backend for enterprise self-hosted `ds1-miru-int8` (TEI-style `/embed`), with setup validation via `miru setup --sagemaker --arn <arn> --profile <name>`
- Make Takara and SageMaker credentials mutually exclusive; lazy-load the AWS SDK so Takara-only MCP/CLI processes avoid the startup cost
- Ship enterprise docs (`docs/self-hosted-sagemaker.md`), Marketplace listing link, and an admin invoke-user runbook (`bun run sagemaker:create-invoke-user`)

## Test plan
- [x] `bun run lint`
- [x] `bun test` (321 pass)
- [x] Walk enterprise docs flow: clear creds → create invoke-only profile → `miru setup --sagemaker` → embed via SageMaker with no Takara egress
- [ ] Review `docs/self-hosted-sagemaker.md` for clarity
- [ ] Confirm PRD-341 / PRD-307 can close once merged