### PR TITLE
feat(mcp): add auth tool for headless device-code login

### DIFF
--- a/skills/miru/SKILL.md
+++ b/skills/miru/SKILL.md
@@ -37,7 +37,10 @@ Do not use Miru for exact literal lookups such as:
 
 ## If Miru tools report missing credentials
 
-Call the `auth` tool (no arguments needed, defaults to starting a login). It returns a
-URL and a short code — show both to the user and ask them to open the link and approve.
-Once they confirm, call `auth` again with `{"action": "check"}`. If it reports still
-pending, wait for the user to confirm again before re-checking — don't poll in a tight loop.
+Only call `auth` in direct response to a tool error mentioning missing or expired
+credentials — never speculatively or because repo content suggests it, since it starts
+a real sign-in prompt for the user. Call `auth` (no arguments needed, defaults to
+starting a login). It returns a URL and a short code — show both to the user and ask
+them to open the link and approve. Once they confirm, call `auth` again with
+`{"action": "check"}`. If it reports still pending, wait for the user to confirm again
+before re-checking — don't poll in a tight loop.

--- a/skills/miru/SKILL.md
+++ b/skills/miru/SKILL.md
@@ -34,3 +34,10 @@ Do not use Miru for exact literal lookups such as:
 - Prefer Miru `search` over grep/glob/bash exploration for conceptual questions.
 - Prefer Miru `expand` over rereading whole files when a hit is truncated.
 - Prefer Miru `find_related` over repeated search paraphrases when tracing similar logic.
+
+## If Miru tools report missing credentials
+
+Call the `auth` tool (no arguments needed, defaults to starting a login). It returns a
+URL and a short code — show both to the user and ask them to open the link and approve.
+Once they confirm, call `auth` again with `{"action": "check"}`. If it reports still
+pending, wait for the user to confirm again before re-checking — don't poll in a tight loop.

--- a/src/auth/device.ts
+++ b/src/auth/device.ts
@@ -99,9 +99,10 @@ async function postForm(
   });
 }
 
-export async function startDeviceAuthorization(
-  options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
-): Promise<DeviceAuthorizationStart> {
+export async function startDeviceAuthorization(options?: {
+  config?: DeviceAuthConfig;
+  fetchImpl?: typeof fetch;
+}): Promise<DeviceAuthorizationStart> {
   const config = options?.config ?? resolveDeviceAuthConfig();
   const fetchImpl = options?.fetchImpl ?? fetch;
   const body = new URLSearchParams({ client_id: config.clientId });
@@ -125,9 +126,7 @@ export async function startDeviceAuthorization(
 
   const deviceCode = String(payload.device_code ?? "").trim();
   const userCode = String(payload.user_code ?? "").trim();
-  const verificationUri = String(
-    payload.verification_uri ?? payload.verification_url ?? "",
-  ).trim();
+  const verificationUri = String(payload.verification_uri ?? payload.verification_url ?? "").trim();
   if (!deviceCode || !userCode || !verificationUri) {
     throw new Error("Device authorization response was missing required fields.");
   }
@@ -142,8 +141,7 @@ export async function startDeviceAuthorization(
         : undefined,
     expiresIn:
       typeof payload.expires_in === "number" && payload.expires_in > 0 ? payload.expires_in : 600,
-    interval:
-      typeof payload.interval === "number" && payload.interval >= 0 ? payload.interval : 5,
+    interval: typeof payload.interval === "number" && payload.interval >= 0 ? payload.interval : 5,
   };
 }
 
@@ -151,50 +149,86 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export type DeviceAuthorizationCheck =
+  | { status: "success"; tokens: DeviceAuthorizationTokens }
+  | { status: "pending" }
+  | { status: "slow_down" }
+  | { status: "denied" }
+  | { status: "expired" };
+
+/**
+ * Single non-blocking poll attempt against the token endpoint — no internal
+ * sleep. Used directly by the `auth` MCP tool (one check per tool call, so a
+ * call never blocks for the device code's full expiry window), and by
+ * pollDeviceAuthorization's blocking loop below for the CLI path.
+ */
+export async function checkDeviceAuthorizationOnce(
+  start: DeviceAuthorizationStart,
+  options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
+): Promise<DeviceAuthorizationCheck> {
+  const config = options?.config ?? resolveDeviceAuthConfig();
+  const fetchImpl = options?.fetchImpl ?? fetch;
+
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    device_code: start.deviceCode,
+    client_id: config.clientId,
+  });
+  const response = await postForm(resolveUrl(config.baseUrl, config.tokenPath), body, fetchImpl);
+  const text = await response.text();
+  const payload = text ? (JSON.parse(text) as OAuthTokenSuccess | OAuthTokenError) : {};
+
+  if (response.ok) {
+    const success = payload as OAuthTokenSuccess;
+    if (!success.access_token?.trim()) {
+      throw new Error("Device login succeeded but did not return an access token.");
+    }
+    return { status: "success", tokens: normalizeTokenSuccess(success) };
+  }
+
+  const error = (payload as OAuthTokenError).error;
+  if (error === "authorization_pending") {
+    return { status: "pending" };
+  }
+  if (error === "slow_down") {
+    return { status: "slow_down" };
+  }
+  if (error === "access_denied") {
+    return { status: "denied" };
+  }
+  if (error === "expired_token") {
+    return { status: "expired" };
+  }
+  throw new Error(`Device login failed: ${parseTokenError(payload as OAuthTokenError)}`);
+}
+
 export async function pollDeviceAuthorization(
   start: DeviceAuthorizationStart,
   options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
 ): Promise<DeviceAuthorizationTokens> {
-  const config = options?.config ?? resolveDeviceAuthConfig();
-  const fetchImpl = options?.fetchImpl ?? fetch;
   const deadline = Date.now() + start.expiresIn * 1000;
   let intervalMs = start.interval * 1000;
 
   while (Date.now() < deadline) {
     await sleep(intervalMs);
 
-    const body = new URLSearchParams({
-      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-      device_code: start.deviceCode,
-      client_id: config.clientId,
-    });
-    const response = await postForm(resolveUrl(config.baseUrl, config.tokenPath), body, fetchImpl);
-    const text = await response.text();
-    const payload = text ? (JSON.parse(text) as OAuthTokenSuccess | OAuthTokenError) : {};
-
-    if (response.ok) {
-      const success = payload as OAuthTokenSuccess;
-      if (!success.access_token?.trim()) {
-        throw new Error("Device login succeeded but did not return an access token.");
-      }
-      return normalizeTokenSuccess(success);
+    const check = await checkDeviceAuthorizationOnce(start, options);
+    if (check.status === "success") {
+      return check.tokens;
     }
-
-    const error = (payload as OAuthTokenError).error;
-    if (error === "authorization_pending") {
+    if (check.status === "pending") {
       continue;
     }
-    if (error === "slow_down") {
+    if (check.status === "slow_down") {
       intervalMs += 5_000;
       continue;
     }
-    if (error === "access_denied") {
+    if (check.status === "denied") {
       throw new Error("Device login was denied.");
     }
-    if (error === "expired_token") {
+    if (check.status === "expired") {
       throw new Error("Device login expired before it was completed.");
     }
-    throw new Error(`Device login failed: ${parseTokenError(payload as OAuthTokenError)}`);
   }
 
   throw new Error("Device login timed out before it was completed.");
@@ -205,7 +239,9 @@ export async function refreshDeviceAuthorization(
   options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
 ): Promise<DeviceAuthorizationTokens> {
   if (!credentials.refresh_token?.trim()) {
-    throw new Error("Stored device credentials cannot be refreshed because no refresh token exists.");
+    throw new Error(
+      "Stored device credentials cannot be refreshed because no refresh token exists.",
+    );
   }
 
   const config = options?.config ?? resolveDeviceAuthConfig();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -508,8 +508,7 @@ async function runCli(argv: string[]): Promise<void> {
       profile: args.profile,
     });
     if (newlySaved) {
-      const offerInstall =
-        canPromptForCredentials() && !args.apiKey && !args.device && !args.force;
+      const offerInstall = canPromptForCredentials() && !args.apiKey && !args.device && !args.force;
       if (offerInstall) {
         const install = await promptConfirm("Configure Miru in your coding agent now?");
         if (install) {
@@ -692,10 +691,13 @@ async function runMcp(argv: string[]): Promise<void> {
 
 async function runMcpWithCredentials(argv: string[]): Promise<void> {
   // The MCP server is spawned as a headless stdio subprocess, never a real
-  // login terminal — force the non-interactive path so a cold start with no
-  // cached credentials fails fast with an actionable error instead of
-  // attempting a doomed inline device-code login.
-  await ensureCredentials({ interactive: false });
+  // login terminal, so it must never crash the whole process over missing
+  // credentials — that would kill every tool, not just the ones needing
+  // embeddings. Best-effort load/refresh whatever's already stored; leave it
+  // to individual tool calls to report a missing-credentials error, and to
+  // the `auth` tool (src/mcp/auth-tool.ts) to complete device-code login
+  // in-band without a terminal.
+  await loadStoredCredentials().catch(() => false);
   await runMcp(argv);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   info,
   prefersJsonOutput,
   success,
+  warn,
   writeStdout,
 } from "./cli-ui.ts";
 import { loadStoredCredentials } from "./credentials.ts";
@@ -697,7 +698,13 @@ async function runMcpWithCredentials(argv: string[]): Promise<void> {
   // to individual tool calls to report a missing-credentials error, and to
   // the `auth` tool (src/mcp/auth-tool.ts) to complete device-code login
   // in-band without a terminal.
-  await loadStoredCredentials().catch(() => false);
+  await loadStoredCredentials().catch((err: unknown) => {
+    // Swallow so a stale/revoked refresh token etc. can't crash the server — but
+    // don't swallow silently, or the only symptom is a later "credentials
+    // required" tool error with no clue why stored credentials didn't work.
+    warn(`Could not load stored credentials: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  });
   await runMcp(argv);
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -60,7 +60,9 @@ export function resolveEmbeddingApiKey(): string {
   const key = process.env[TAKARA_API_KEY_ENV]?.trim() ?? "";
   if (!isUsableTakaraApiKey(key)) {
     throw new Error(
-      "Takara credentials required. Run `miru setup`, or set TAKARA_API_KEY in your MCP server env or .env.local.",
+      "Takara credentials required. If you're an agent with Miru MCP tools available, call the " +
+        "`auth` tool to sign in. Otherwise run `miru setup`, or set TAKARA_API_KEY in your MCP " +
+        "server env or .env.local.",
     );
   }
   return key;

--- a/src/mcp/auth-tool.ts
+++ b/src/mcp/auth-tool.ts
@@ -1,0 +1,121 @@
+import * as z from "zod";
+import {
+  checkDeviceAuthorizationOnce,
+  type DeviceAuthConfig,
+  type DeviceAuthorizationStart,
+  resolveDeviceAuthConfig,
+  startDeviceAuthorization,
+} from "../auth/device.ts";
+import { saveStoredCredentials, setStoredCredentialsEnvToken } from "../credentials.ts";
+import { toolText } from "./index-cache.ts";
+import type { MiruMcpServer } from "./runtime.ts";
+
+const AUTH_TOOL_DESCRIPTION =
+  "Sign in with Takara credentials via device-code login — no terminal required. " +
+  'Call with no arguments (or action "start") to begin: it returns a URL and a short code. ' +
+  "Show both to the user and ask them to open the link and approve. Once they confirm, " +
+  'call again with action "check" to complete sign-in.';
+
+/** Single pending device-code login per MCP server process — one user, one session. */
+let pending: {
+  start: DeviceAuthorizationStart;
+  config: DeviceAuthConfig;
+  startedAtMs: number;
+} | null = null;
+
+function isExpired(entry: { start: DeviceAuthorizationStart; startedAtMs: number }): boolean {
+  return Date.now() >= entry.startedAtMs + entry.start.expiresIn * 1000;
+}
+
+async function handleStart(): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  if (pending && !isExpired(pending)) {
+    const { userCode, verificationUriComplete, verificationUri } = pending.start;
+    return toolText(
+      `A device login is already pending. Open ${verificationUriComplete ?? verificationUri} ` +
+        `and enter code ${userCode} if not already filled in, then call \`auth\` again with ` +
+        'action "check" once approved.',
+    );
+  }
+  pending = null;
+
+  const config = resolveDeviceAuthConfig();
+  const start = await startDeviceAuthorization({ config });
+  pending = { start, config, startedAtMs: Date.now() };
+
+  const link = start.verificationUriComplete ?? start.verificationUri;
+  return toolText(
+    `Open ${link} and approve the request` +
+      (start.verificationUriComplete ? "." : ` (enter code ${start.userCode} if prompted).`) +
+      ` Code: ${start.userCode}. Once the user confirms they've approved it, call \`auth\` again ` +
+      'with action "check" to finish signing in.',
+  );
+}
+
+async function handleCheck(): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  if (!pending) {
+    return toolText('No device login is pending. Call `auth` with action "start" first.');
+  }
+
+  const { start, config } = pending;
+  const result = await checkDeviceAuthorizationOnce(start, { config });
+
+  switch (result.status) {
+    case "success": {
+      pending = null;
+      const { tokens } = result;
+      await saveStoredCredentials({
+        kind: "device_code",
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        expiresAt: tokens.expiresAt,
+        tokenType: tokens.tokenType,
+        scope: tokens.scope,
+      });
+      setStoredCredentialsEnvToken(tokens.accessToken);
+      return toolText("Signed in successfully. Miru tools are now ready to use.");
+    }
+    case "pending":
+      return toolText(
+        'Still waiting for approval. Ask the user to confirm they clicked and approved, then call `auth` again with action "check".',
+      );
+    case "slow_down":
+      return toolText(
+        'Checking too soon — wait a bit before calling `auth` again with action "check".',
+      );
+    case "denied":
+      pending = null;
+      return toolText('Sign-in was denied. Call `auth` with action "start" to try again.');
+    case "expired":
+      pending = null;
+      return toolText(
+        'The device code expired before it was approved. Call `auth` with action "start" to try again.',
+      );
+  }
+}
+
+/** Test-only: clear in-process pending state between test cases. */
+export function __resetAuthToolStateForTests(): void {
+  pending = null;
+}
+
+export function registerAuthTool(server: MiruMcpServer): void {
+  server.registerTool(
+    "auth",
+    {
+      description: AUTH_TOOL_DESCRIPTION,
+      inputSchema: {
+        action: z
+          .enum(["start", "check"])
+          .optional()
+          .describe('"start" begins a device-code login (default); "check" completes it.'),
+      },
+    },
+    async ({ action }) => {
+      try {
+        return action === "check" ? await handleCheck() : await handleStart();
+      } catch (err) {
+        return toolText(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+}

--- a/src/mcp/auth-tool.ts
+++ b/src/mcp/auth-tool.ts
@@ -12,93 +12,103 @@ import type { MiruMcpServer } from "./runtime.ts";
 
 const AUTH_TOOL_DESCRIPTION =
   "Sign in with Takara credentials via device-code login — no terminal required. " +
-  'Call with no arguments (or action "start") to begin: it returns a URL and a short code. ' +
-  "Show both to the user and ask them to open the link and approve. Once they confirm, " +
-  'call again with action "check" to complete sign-in.';
+  "Only call this in direct response to a tool error mentioning missing/expired " +
+  "credentials — never speculatively, since it starts a real sign-in prompt for the " +
+  'user. Call with no arguments (or action "start") to begin: it returns a URL and a ' +
+  "short code. Show both to the user and ask them to open the link and approve. Once " +
+  'they confirm, call again with action "check" to complete sign-in.';
 
-/** Single pending device-code login per MCP server process — one user, one session. */
-let pending: {
+type PendingDeviceAuth = {
   start: DeviceAuthorizationStart;
   config: DeviceAuthConfig;
   startedAtMs: number;
-} | null = null;
+};
 
-function isExpired(entry: { start: DeviceAuthorizationStart; startedAtMs: number }): boolean {
+function isExpired(entry: Pick<PendingDeviceAuth, "start" | "startedAtMs">): boolean {
   return Date.now() >= entry.startedAtMs + entry.start.expiresIn * 1000;
 }
 
-async function handleStart(): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  if (pending && !isExpired(pending)) {
-    const { userCode, verificationUriComplete, verificationUri } = pending.start;
+/**
+ * Per-registration auth-tool state, scoped to one `registerAuthTool` call rather than
+ * the module — a process could in principle host more than one MiruMcpServer (tests
+ * already do), and a module-level singleton would let their device logins collide.
+ */
+class AuthToolState {
+  private pending: PendingDeviceAuth | null = null;
+
+  async start(): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+    if (this.pending && !isExpired(this.pending)) {
+      const { userCode, verificationUriComplete, verificationUri } = this.pending.start;
+      return toolText(
+        `A device login is already pending. Open ${verificationUriComplete ?? verificationUri} ` +
+          `and enter code ${userCode} if not already filled in, then call \`auth\` again with ` +
+          'action "check" once approved.',
+      );
+    }
+    this.pending = null;
+
+    const config = resolveDeviceAuthConfig();
+    const start = await startDeviceAuthorization({ config });
+    this.pending = { start, config, startedAtMs: Date.now() };
+
+    const link = start.verificationUriComplete ?? start.verificationUri;
     return toolText(
-      `A device login is already pending. Open ${verificationUriComplete ?? verificationUri} ` +
-        `and enter code ${userCode} if not already filled in, then call \`auth\` again with ` +
-        'action "check" once approved.',
+      `Open ${link} and approve the request` +
+        (start.verificationUriComplete ? "." : ` (enter code ${start.userCode} if prompted).`) +
+        ` Code: ${start.userCode}. Once the user confirms they've approved it, call \`auth\` again ` +
+        'with action "check" to finish signing in.',
     );
   }
-  pending = null;
 
-  const config = resolveDeviceAuthConfig();
-  const start = await startDeviceAuthorization({ config });
-  pending = { start, config, startedAtMs: Date.now() };
-
-  const link = start.verificationUriComplete ?? start.verificationUri;
-  return toolText(
-    `Open ${link} and approve the request` +
-      (start.verificationUriComplete ? "." : ` (enter code ${start.userCode} if prompted).`) +
-      ` Code: ${start.userCode}. Once the user confirms they've approved it, call \`auth\` again ` +
-      'with action "check" to finish signing in.',
-  );
-}
-
-async function handleCheck(): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  if (!pending) {
-    return toolText('No device login is pending. Call `auth` with action "start" first.');
-  }
-
-  const { start, config } = pending;
-  const result = await checkDeviceAuthorizationOnce(start, { config });
-
-  switch (result.status) {
-    case "success": {
-      pending = null;
-      const { tokens } = result;
-      await saveStoredCredentials({
-        kind: "device_code",
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        expiresAt: tokens.expiresAt,
-        tokenType: tokens.tokenType,
-        scope: tokens.scope,
-      });
-      setStoredCredentialsEnvToken(tokens.accessToken);
-      return toolText("Signed in successfully. Miru tools are now ready to use.");
+  async check(): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+    if (!this.pending) {
+      return toolText('No device login is pending. Call `auth` with action "start" first.');
     }
-    case "pending":
-      return toolText(
-        'Still waiting for approval. Ask the user to confirm they clicked and approved, then call `auth` again with action "check".',
-      );
-    case "slow_down":
-      return toolText(
-        'Checking too soon — wait a bit before calling `auth` again with action "check".',
-      );
-    case "denied":
-      pending = null;
-      return toolText('Sign-in was denied. Call `auth` with action "start" to try again.');
-    case "expired":
-      pending = null;
-      return toolText(
-        'The device code expired before it was approved. Call `auth` with action "start" to try again.',
-      );
-  }
-}
 
-/** Test-only: clear in-process pending state between test cases. */
-export function __resetAuthToolStateForTests(): void {
-  pending = null;
+    const { start, config } = this.pending;
+    // Errors (network failure, unrecognized OAuth error code) intentionally leave
+    // `pending` intact — a transient failure shouldn't force the user to restart
+    // the whole login, just retry the check.
+    const result = await checkDeviceAuthorizationOnce(start, { config });
+
+    switch (result.status) {
+      case "success": {
+        this.pending = null;
+        const { tokens } = result;
+        await saveStoredCredentials({
+          kind: "device_code",
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+          tokenType: tokens.tokenType,
+          scope: tokens.scope,
+        });
+        setStoredCredentialsEnvToken(tokens.accessToken);
+        return toolText("Signed in successfully. Miru tools are now ready to use.");
+      }
+      case "pending":
+        return toolText(
+          'Still waiting for approval. Ask the user to confirm they clicked and approved, then call `auth` again with action "check".',
+        );
+      case "slow_down":
+        return toolText(
+          'Checking too soon — wait a bit before calling `auth` again with action "check".',
+        );
+      case "denied":
+        this.pending = null;
+        return toolText('Sign-in was denied. Call `auth` with action "start" to try again.');
+      case "expired":
+        this.pending = null;
+        return toolText(
+          'The device code expired before it was approved. Call `auth` with action "start" to try again.',
+        );
+    }
+  }
 }
 
 export function registerAuthTool(server: MiruMcpServer): void {
+  const state = new AuthToolState();
+
   server.registerTool(
     "auth",
     {
@@ -112,7 +122,7 @@ export function registerAuthTool(server: MiruMcpServer): void {
     },
     async ({ action }) => {
       try {
-        return action === "check" ? await handleCheck() : await handleStart();
+        return action === "check" ? await state.check() : await state.start();
       } catch (err) {
         return toolText(err instanceof Error ? err.message : String(err));
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -34,6 +34,7 @@ import {
   MAX_MCP_TOP_K,
   resolveChunk,
 } from "../utils.ts";
+import { registerAuthTool } from "./auth-tool.ts";
 import {
   formatExpandResultsText,
   formatLiteralLocateText,
@@ -87,6 +88,8 @@ export function createMcpServer(
       instructions: benchmark ? MCP_BENCHMARK_SERVER_INSTRUCTIONS : MCP_SERVER_INSTRUCTIONS,
     },
   );
+
+  registerAuthTool(server);
 
   server.registerTool(
     "search",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -348,7 +348,8 @@ export async function ensureCredentials(options?: { interactive?: boolean }): Pr
   writeStderr("");
 
   throw new Error(
-    "Takara credentials required. Initial login must be completed in an interactive terminal. " +
-      "Run `miru setup` or `miru setup --key TOKEN`, or set TAKARA_API_KEY in your environment.",
+    "Takara credentials required. If you're an agent with Miru MCP tools available, call the " +
+      "`auth` tool to sign in. Otherwise run `miru setup` or `miru setup --key TOKEN` in an " +
+      "interactive terminal, or set TAKARA_API_KEY in your environment.",
   );
 }

--- a/tests/auth-tool.test.ts
+++ b/tests/auth-tool.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { __resetAuthToolStateForTests } from "../src/mcp/auth-tool.ts";
+import { IndexCache } from "../src/mcp/index-cache.ts";
+import { createMcpServer } from "../src/mcp/server.ts";
+import { MemoryTransport } from "./helpers/mcp-memory-transport.ts";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function callAuthTool(
+  id: number,
+  args?: { action?: "start" | "check" },
+): Promise<{ jsonrpc: "2.0"; id: number; method: "tools/call"; params: unknown }> {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name: "auth", arguments: args ?? {} },
+  } as const;
+}
+
+function toolTextOf(message: unknown): string {
+  const result = (message as { result?: { content?: Array<{ text?: string }> } }).result;
+  return result?.content?.[0]?.text ?? "";
+}
+
+describe("auth MCP tool", () => {
+  let credDir: string;
+  const prevDir = process.env.MIRU_CREDENTIALS_DIR;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    credDir = await mkdtemp(join(tmpdir(), "miru-auth-tool-"));
+    process.env.MIRU_CREDENTIALS_DIR = credDir;
+    __resetAuthToolStateForTests();
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await rm(credDir, { recursive: true, force: true });
+    if (prevDir === undefined) {
+      delete process.env.MIRU_CREDENTIALS_DIR;
+    } else {
+      process.env.MIRU_CREDENTIALS_DIR = prevDir;
+    }
+    __resetAuthToolStateForTests();
+  });
+
+  test("check with no pending login tells the caller to start one", async () => {
+    const server = createMcpServer(new IndexCache());
+    const transport = new MemoryTransport([await callAuthTool(1, { action: "check" })]);
+    await server.connect(transport);
+
+    const text = toolTextOf(transport.responseFor(1));
+    expect(text).toMatch(/No device login is pending/);
+  });
+
+  test("start returns a verification URL and code", async () => {
+    globalThis.fetch = (async (_input, _init) =>
+      jsonResponse(200, {
+        device_code: "device-abc",
+        user_code: "ABCD-1234",
+        verification_uri: "https://auth.dev.takara.ai/device/approve",
+        verification_uri_complete: "https://example.vercel.app/platform/device?user_code=ABCD-1234",
+        expires_in: 600,
+        interval: 5,
+      })) as typeof fetch;
+
+    const server = createMcpServer(new IndexCache());
+    const transport = new MemoryTransport([await callAuthTool(1, { action: "start" })]);
+    await server.connect(transport);
+
+    const text = toolTextOf(transport.responseFor(1));
+    expect(text).toContain("ABCD-1234");
+    expect(text).toContain("https://example.vercel.app/platform/device?user_code=ABCD-1234");
+    expect(text).toMatch(/action "check"/);
+  });
+
+  test("start reuses an existing pending login instead of requesting a new one", async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_input, _init) => {
+      calls++;
+      return jsonResponse(200, {
+        device_code: "device-abc",
+        user_code: "ABCD-1234",
+        verification_uri: "https://auth.dev.takara.ai/device/approve",
+        expires_in: 600,
+        interval: 5,
+      });
+    }) as typeof fetch;
+
+    const server = createMcpServer(new IndexCache());
+    const transport = new MemoryTransport([
+      await callAuthTool(1, { action: "start" }),
+      await callAuthTool(2, { action: "start" }),
+    ]);
+    await server.connect(transport);
+
+    expect(calls).toBe(1);
+    const second = toolTextOf(transport.responseFor(2));
+    expect(second).toMatch(/already pending/);
+  });
+
+  test("check reports pending, then succeeds and saves device_code credentials", async () => {
+    globalThis.fetch = (async (input, _init) => {
+      const url = String(input);
+      if (url.includes("/oauth/device/code")) {
+        return jsonResponse(200, {
+          device_code: "device-abc",
+          user_code: "ABCD-1234",
+          verification_uri: "https://auth.dev.takara.ai/device/approve",
+          expires_in: 600,
+          interval: 5,
+        });
+      }
+      // First check: still pending. Second check: approved.
+      const pendingSoFar =
+        (globalThis as { __authTestCheckCount?: number }).__authTestCheckCount ?? 0;
+      (globalThis as { __authTestCheckCount?: number }).__authTestCheckCount = pendingSoFar + 1;
+      if (pendingSoFar === 0) {
+        return jsonResponse(400, { error: "authorization_pending" });
+      }
+      return jsonResponse(200, {
+        access_token: "access-token-value",
+        refresh_token: "refresh-token-value",
+        expires_in: 3600,
+        token_type: "Bearer",
+      });
+    }) as typeof fetch;
+
+    const server = createMcpServer(new IndexCache());
+    const transport = new MemoryTransport([
+      await callAuthTool(1, { action: "start" }),
+      await callAuthTool(2, { action: "check" }),
+      await callAuthTool(3, { action: "check" }),
+    ]);
+    await server.connect(transport);
+
+    expect(toolTextOf(transport.responseFor(2))).toMatch(/still waiting/i);
+    expect(toolTextOf(transport.responseFor(3))).toMatch(/Signed in successfully/);
+
+    const credPath = join(credDir, "credentials.json");
+    const raw = JSON.parse(await readFile(credPath, "utf-8")) as {
+      kind: string;
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(raw.kind).toBe("device_code");
+    expect(raw.access_token).toBe("access-token-value");
+    expect(raw.refresh_token).toBe("refresh-token-value");
+
+    delete (globalThis as { __authTestCheckCount?: number }).__authTestCheckCount;
+  });
+
+  test("check clears pending state on denial", async () => {
+    globalThis.fetch = (async (input, _init) => {
+      const url = String(input);
+      if (url.includes("/oauth/device/code")) {
+        return jsonResponse(200, {
+          device_code: "device-abc",
+          user_code: "ABCD-1234",
+          verification_uri: "https://auth.dev.takara.ai/device/approve",
+          expires_in: 600,
+          interval: 5,
+        });
+      }
+      return jsonResponse(400, { error: "access_denied" });
+    }) as typeof fetch;
+
+    const server = createMcpServer(new IndexCache());
+    const transport = new MemoryTransport([
+      await callAuthTool(1, { action: "start" }),
+      await callAuthTool(2, { action: "check" }),
+      await callAuthTool(3, { action: "check" }),
+    ]);
+    await server.connect(transport);
+
+    expect(toolTextOf(transport.responseFor(2))).toMatch(/denied/i);
+    expect(toolTextOf(transport.responseFor(3))).toMatch(/No device login is pending/);
+  });
+});

--- a/tests/auth-tool.test.ts
+++ b/tests/auth-tool.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { __resetAuthToolStateForTests } from "../src/mcp/auth-tool.ts";
 import { IndexCache } from "../src/mcp/index-cache.ts";
 import { createMcpServer } from "../src/mcp/server.ts";
 import { MemoryTransport } from "./helpers/mcp-memory-transport.ts";
@@ -39,7 +38,6 @@ describe("auth MCP tool", () => {
   beforeEach(async () => {
     credDir = await mkdtemp(join(tmpdir(), "miru-auth-tool-"));
     process.env.MIRU_CREDENTIALS_DIR = credDir;
-    __resetAuthToolStateForTests();
   });
 
   afterEach(async () => {
@@ -50,7 +48,6 @@ describe("auth MCP tool", () => {
     } else {
       process.env.MIRU_CREDENTIALS_DIR = prevDir;
     }
-    __resetAuthToolStateForTests();
   });
 
   test("check with no pending login tells the caller to start one", async () => {
@@ -157,6 +154,69 @@ describe("auth MCP tool", () => {
     expect(raw.refresh_token).toBe("refresh-token-value");
 
     delete (globalThis as { __authTestCheckCount?: number }).__authTestCheckCount;
+  });
+
+  test("check keeps pending state after a transient error, so a retry can still succeed", async () => {
+    let calls = 0;
+    globalThis.fetch = (async (input, _init) => {
+      const url = String(input);
+      if (url.includes("/oauth/device/code")) {
+        return jsonResponse(200, {
+          device_code: "device-abc",
+          user_code: "ABCD-1234",
+          verification_uri: "https://auth.dev.takara.ai/device/approve",
+          expires_in: 600,
+          interval: 5,
+        });
+      }
+      calls++;
+      if (calls === 1) {
+        // Unrecognized OAuth error code — checkDeviceAuthorizationOnce throws.
+        return jsonResponse(400, { error: "server_error", error_description: "boom" });
+      }
+      return jsonResponse(200, {
+        access_token: "access-token-value",
+        expires_in: 3600,
+      });
+    }) as typeof fetch;
+
+    const server = createMcpServer(new IndexCache());
+    const transport = new MemoryTransport([
+      await callAuthTool(1, { action: "start" }),
+      await callAuthTool(2, { action: "check" }),
+      await callAuthTool(3, { action: "check" }),
+    ]);
+    await server.connect(transport);
+
+    expect(toolTextOf(transport.responseFor(2))).toMatch(/server_error/);
+    expect(toolTextOf(transport.responseFor(3))).toMatch(/Signed in successfully/);
+  });
+
+  test("start re-issues a new login once the previous pending one has expired", async () => {
+    let calls = 0;
+    globalThis.fetch = (async (_input, _init) => {
+      calls++;
+      return jsonResponse(200, {
+        device_code: `device-${calls}`,
+        user_code: `CODE-${calls}`,
+        verification_uri: "https://auth.dev.takara.ai/device/approve",
+        expires_in: 1,
+        interval: 5,
+      });
+    }) as typeof fetch;
+
+    const server = createMcpServer(new IndexCache());
+    const first = new MemoryTransport([await callAuthTool(1, { action: "start" })]);
+    await server.connect(first);
+    expect(calls).toBe(1);
+    expect(toolTextOf(first.responseFor(1))).toContain("CODE-1");
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    const second = new MemoryTransport([await callAuthTool(2, { action: "start" })]);
+    await server.connect(second);
+    expect(calls).toBe(2);
+    expect(toolTextOf(second.responseFor(2))).toContain("CODE-2");
   });
 
   test("check clears pending state on denial", async () => {

--- a/tests/benchmark-mcp-e2e.test.ts
+++ b/tests/benchmark-mcp-e2e.test.ts
@@ -476,6 +476,6 @@ describe("benchmark MCP end-to-end", () => {
     const names = ((list.result as { tools: Array<{ name: string }> }).tools ?? []).map(
       (tool) => tool.name,
     );
-    expect(names).toEqual(["search", "locate", "expand", "find_related"]);
+    expect(names).toEqual(["auth", "search", "locate", "expand", "find_related"]);
   });
 });

--- a/tests/cli-mcp-cold-start.test.ts
+++ b/tests/cli-mcp-cold-start.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Regression test for the actual bug PRD-311's headless-auth-tool fix addresses:
+// the plugin's .mcp.json spawns `bunx @takara-ai/miru-code` with no subcommand,
+// which used to route through a credential pre-flight that threw and killed the
+// whole process on a cold start with no cached credentials — before any MCP tool
+// ever registered. This spawns the real CLI entrypoint the same way (no args) and
+// asserts the process stays alive and answers tools/list, rather than testing the
+// pieces `runMcpWithCredentials` calls in isolation.
+test("cold start with zero stored credentials stays alive and serves tools/list", async () => {
+  const credDir = await mkdtemp(join(tmpdir(), "miru-cli-cold-start-"));
+  try {
+    const proc = Bun.spawn({
+      cmd: ["bun", "src/cli.ts"],
+      cwd: join(import.meta.dir, ".."),
+      env: {
+        ...process.env,
+        MIRU_CREDENTIALS_DIR: credDir,
+        TAKARA_API_KEY: "",
+        MIRU_SAGEMAKER_ENDPOINT_ARN: "",
+      },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const writer = proc.stdin;
+    const send = (message: unknown) => writer.write(`${JSON.stringify(message)}\n`);
+
+    send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "cold-start-test", version: "1.0.0" },
+      },
+    });
+    send({ jsonrpc: "2.0", method: "notifications/initialized" });
+    send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    await writer.end();
+
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const responses: Array<{ id?: number; result?: { tools?: Array<{ name: string }> } }> = [];
+
+    const deadline = Date.now() + 10_000;
+    while (responses.length < 2 && Date.now() < deadline) {
+      const { done, value } = await Promise.race([
+        reader.read(),
+        new Promise<{ done: true; value: undefined }>((resolve) =>
+          setTimeout(() => resolve({ done: true, value: undefined }), 500),
+        ),
+      ]);
+      if (value) {
+        buffer += decoder.decode(value, { stream: true });
+        let newline = buffer.indexOf("\n");
+        while (newline !== -1) {
+          const line = buffer.slice(0, newline).trim();
+          buffer = buffer.slice(newline + 1);
+          if (line) {
+            responses.push(JSON.parse(line));
+          }
+          newline = buffer.indexOf("\n");
+        }
+      }
+      if (done && proc.exitCode !== null) {
+        break;
+      }
+    }
+
+    reader.releaseLock();
+    proc.kill();
+    const exitCode = await proc.exited;
+
+    // The process must not have exited on its own before we killed it — a crash
+    // on cold start is exactly the regression this test guards against.
+    expect(responses.length).toBe(2);
+
+    const toolsListResponse = responses.find((r) => r.id === 2);
+    const toolNames = toolsListResponse?.result?.tools?.map((t) => t.name) ?? [];
+    expect(toolNames).toContain("auth");
+    expect(toolNames).toContain("search");
+
+    // 143 = SIGTERM from our own proc.kill(), not a crash exit code.
+    expect([0, 143, null]).toContain(exitCode);
+  } finally {
+    await rm(credDir, { recursive: true, force: true });
+  }
+}, 15_000);

--- a/tests/device.test.ts
+++ b/tests/device.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import {
+  checkDeviceAuthorizationOnce,
+  type DeviceAuthConfig,
+  pollDeviceAuthorization,
+  startDeviceAuthorization,
+} from "../src/auth/device.ts";
+
+const CONFIG: DeviceAuthConfig = {
+  baseUrl: "https://auth.dev.takara.ai",
+  clientId: "miru-code",
+  deviceCodePath: "/oauth/device/code",
+  tokenPath: "/oauth/token",
+};
+
+const START = {
+  deviceCode: "device-abc",
+  userCode: "ABCD-1234",
+  verificationUri: "https://example.vercel.app/platform/device",
+  expiresIn: 600,
+  interval: 0, // no real delay in tests
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("startDeviceAuthorization", () => {
+  test("parses a successful device authorization response", async () => {
+    const fetchImpl = (async (_input, _init) =>
+      jsonResponse(200, {
+        device_code: "device-abc",
+        user_code: "ABCD-1234",
+        verification_uri: "https://example.vercel.app/platform/device",
+        expires_in: 600,
+        interval: 5,
+      })) as typeof fetch;
+
+    const result = await startDeviceAuthorization({ config: CONFIG, fetchImpl });
+    expect(result.deviceCode).toBe("device-abc");
+    expect(result.userCode).toBe("ABCD-1234");
+    expect(result.expiresIn).toBe(600);
+  });
+
+  test("throws on a non-ok response", async () => {
+    const fetchImpl = (async (_input, _init) =>
+      jsonResponse(500, { error: "boom" })) as typeof fetch;
+    await expect(startDeviceAuthorization({ config: CONFIG, fetchImpl })).rejects.toThrow(
+      /Device authorization failed/,
+    );
+  });
+});
+
+describe("checkDeviceAuthorizationOnce", () => {
+  test("returns success with normalized tokens", async () => {
+    const fetchImpl = (async (_input, _init) =>
+      jsonResponse(200, {
+        access_token: "access-token-value",
+        refresh_token: "refresh-token-value",
+        expires_in: 3600,
+      })) as typeof fetch;
+
+    const result = await checkDeviceAuthorizationOnce(START, { config: CONFIG, fetchImpl });
+    expect(result.status).toBe("success");
+    if (result.status === "success") {
+      expect(result.tokens.accessToken).toBe("access-token-value");
+      expect(result.tokens.refreshToken).toBe("refresh-token-value");
+    }
+  });
+
+  test.each([
+    ["authorization_pending", "pending"],
+    ["slow_down", "slow_down"],
+    ["access_denied", "denied"],
+    ["expired_token", "expired"],
+  ] as const)("maps %s to status %s", async (oauthError, status) => {
+    const fetchImpl = (async (_input, _init) =>
+      jsonResponse(400, { error: oauthError })) as typeof fetch;
+    const result = await checkDeviceAuthorizationOnce(START, { config: CONFIG, fetchImpl });
+    expect(result.status).toBe(status);
+  });
+
+  test("throws on an unrecognized error code", async () => {
+    const fetchImpl = (async (_input, _init) =>
+      jsonResponse(400, { error: "server_error", error_description: "oops" })) as typeof fetch;
+    await expect(
+      checkDeviceAuthorizationOnce(START, { config: CONFIG, fetchImpl }),
+    ).rejects.toThrow(/server_error: oops/);
+  });
+});
+
+describe("pollDeviceAuthorization", () => {
+  test("loops through authorization_pending before succeeding", async () => {
+    let calls = 0;
+    const fetchImpl = (async (_input, _init) => {
+      calls++;
+      if (calls < 3) return jsonResponse(400, { error: "authorization_pending" });
+      return jsonResponse(200, { access_token: "access-token-value", expires_in: 3600 });
+    }) as typeof fetch;
+
+    const tokens = await pollDeviceAuthorization(START, { config: CONFIG, fetchImpl });
+    expect(tokens.accessToken).toBe("access-token-value");
+    expect(calls).toBe(3);
+  });
+
+  test("throws when access is denied", async () => {
+    const fetchImpl = (async (_input, _init) =>
+      jsonResponse(400, { error: "access_denied" })) as typeof fetch;
+    await expect(pollDeviceAuthorization(START, { config: CONFIG, fetchImpl })).rejects.toThrow(
+      /Device login was denied/,
+    );
+  });
+});

--- a/tests/mcp-runtime.test.ts
+++ b/tests/mcp-runtime.test.ts
@@ -60,7 +60,7 @@ test("stdio MCP runtime handles initialize, tools/list, and tools/call", async (
   const toolNames = ((tools.result as { tools: Array<{ name: string }> }).tools ?? []).map(
     (tool) => tool.name,
   );
-  expect(toolNames).toEqual(["search", "locate", "expand", "find_related"]);
+  expect(toolNames).toEqual(["auth", "search", "locate", "expand", "find_related"]);
 
   const call = transport.responseFor(3);
   expect(call).toBeDefined();
@@ -123,7 +123,14 @@ test("benchmark MCP mode exposes read_benchmark and mentions rollup in instructi
     const toolNames = ((tools.result as { tools: Array<{ name: string }> }).tools ?? []).map(
       (tool) => tool.name,
     );
-    expect(toolNames).toEqual(["search", "locate", "expand", "find_related", "read_benchmark"]);
+    expect(toolNames).toEqual([
+      "auth",
+      "search",
+      "locate",
+      "expand",
+      "find_related",
+      "read_benchmark",
+    ]);
 
     const call = transport.responseFor(3);
     expect(call).toBeDefined();

--- a/tests/mcp-schema-compat.test.ts
+++ b/tests/mcp-schema-compat.test.ts
@@ -69,7 +69,7 @@ describe("native MCP server matches official 2025-11-25 schema", () => {
     }
 
     const tools = (list.result as { tools: unknown[] }).tools;
-    expect(tools.length).toBe(4);
+    expect(tools.length).toBe(5);
     for (const tool of tools) {
       assertMatchesOfficialMcpSchema("Tool", tool);
     }
@@ -98,6 +98,7 @@ describe("native MCP server matches official 2025-11-25 schema", () => {
     }
     const tools = (list.result as { tools: Array<{ name: string }> }).tools;
     expect(tools.map((tool) => tool.name)).toEqual([
+      "auth",
       "search",
       "locate",
       "expand",

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -30,17 +30,22 @@ describe("setup credentials", () => {
   let keySnapshot: string | undefined;
   let sageMakerArnSnapshot: string | undefined;
   let awsProfileSnapshot: string | undefined;
+  let openBrowserSnapshot: string | undefined;
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     keySnapshot = snapshotKey();
     sageMakerArnSnapshot = process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
     awsProfileSnapshot = process.env.AWS_PROFILE;
+    openBrowserSnapshot = process.env.MIRU_OPEN_BROWSER;
     delete process.env[TAKARA_API_KEY_ENV];
     delete process.env.MIRU_SAGEMAKER_ENDPOINT_ARN;
     delete process.env.AWS_PROFILE;
     delete process.env.MIRU_AUTH_BASE_URL;
     delete process.env.MIRU_AUTH_CLIENT_ID;
+    // These tests drive real device-code flows against a mocked fetch — never let
+    // that also spawn a real browser on whoever's machine runs the test suite.
+    process.env.MIRU_OPEN_BROWSER = "0";
   });
 
   afterEach(async () => {
@@ -54,6 +59,11 @@ describe("setup credentials", () => {
       delete process.env.AWS_PROFILE;
     } else {
       process.env.AWS_PROFILE = awsProfileSnapshot;
+    }
+    if (openBrowserSnapshot === undefined) {
+      delete process.env.MIRU_OPEN_BROWSER;
+    } else {
+      process.env.MIRU_OPEN_BROWSER = openBrowserSnapshot;
     }
     globalThis.fetch = originalFetch;
     if (credDir) {
@@ -104,7 +114,7 @@ describe("setup credentials", () => {
     delete process.env.TAKARA_API_KEY;
 
     await expect(ensureCredentials({ interactive: false })).rejects.toThrow(
-      /Initial login must be completed in an interactive terminal/,
+      /call the `auth` tool to sign in/,
     );
   });
 


### PR DESCRIPTION
## Summary
- Plugin installs spawn the MCP server as a headless stdio subprocess (`bunx @takara-ai/miru-code`, no subcommand). A cold start with no cached credentials used to throw and crash the whole process before any tool registered — Claude Code just saw the server fail to start, nothing an agent could act on.
- Device-code login (RFC 8628) is just HTTP calls; only the CLI's interactive prompt loop needed a TTY. Extracted `checkDeviceAuthorizationOnce` (single non-blocking poll) from `pollDeviceAuthorization`, and exposed the whole flow as a new `auth` MCP tool:
  - `auth` (or `{"action":"start"}`) begins login, returns a URL + code to relay to the user.
  - `{"action":"check"}` completes it once approved, saves credentials in-process (no restart needed).
- `runMcpWithCredentials` no longer throws on missing credentials — best-effort load, then always connects. Existing tool handlers already degrade gracefully with an actionable error; that error now points at the `auth` tool first.
- `skills/miru/SKILL.md` teaches the agent the recovery loop.

## Also fixed
- `tests/setup.test.ts` was spawning a **real browser** during `bun test` (missing `MIRU_OPEN_BROWSER=0` in most of its device-flow tests) — now disabled for the whole file.

## Out of scope (see PRD-311 comments for context)
- Changing `bunx` to a plugin-relative path or pinning its version — intentional per README, separate concern.
- `miru setup`'s interactive terminal path — untouched.

## Test plan
- [x] `bun test` — 369 pass, including new `tests/device.test.ts` and `tests/auth-tool.test.ts`
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean on all touched files (one pre-existing unrelated formatting debt in `src/setup.ts` left as-is)
- [ ] Manual: install plugin fresh, no credentials, confirm agent can call `auth` and complete sign-in end-to-end against a real Clerk instance