### PR TITLE
chore: formatting, biome rules

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,5 @@
     "name": "Takara",
     "url": "https://github.com/takara-ai"
   },
-  "skills": [
-    "./skills/"
-  ]
+  "skills": ["./skills/"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -9,19 +9,9 @@
   "homepage": "https://takara.ai",
   "repository": "https://github.com/takara-ai/miru-code",
   "license": "MIT",
-  "keywords": [
-    "code-search",
-    "semantic-search",
-    "mcp",
-    "agents",
-    "takara"
-  ],
+  "keywords": ["code-search", "semantic-search", "mcp", "agents", "takara"],
   "category": "Productivity",
-  "tags": [
-    "mcp",
-    "semantic-search",
-    "developer-tools"
-  ],
+  "tags": ["mcp", "semantic-search", "developer-tools"],
   "skills": "./skills/",
   "rules": "./.cursor/rules/miru-code-search.mdc",
   "mcpServers": "./.mcp.json"

--- a/src/auth/device.ts
+++ b/src/auth/device.ts
@@ -99,9 +99,10 @@ async function postForm(
   });
 }
 
-export async function startDeviceAuthorization(
-  options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
-): Promise<DeviceAuthorizationStart> {
+export async function startDeviceAuthorization(options?: {
+  config?: DeviceAuthConfig;
+  fetchImpl?: typeof fetch;
+}): Promise<DeviceAuthorizationStart> {
   const config = options?.config ?? resolveDeviceAuthConfig();
   const fetchImpl = options?.fetchImpl ?? fetch;
   const body = new URLSearchParams({ client_id: config.clientId });
@@ -125,9 +126,7 @@ export async function startDeviceAuthorization(
 
   const deviceCode = String(payload.device_code ?? "").trim();
   const userCode = String(payload.user_code ?? "").trim();
-  const verificationUri = String(
-    payload.verification_uri ?? payload.verification_url ?? "",
-  ).trim();
+  const verificationUri = String(payload.verification_uri ?? payload.verification_url ?? "").trim();
   if (!deviceCode || !userCode || !verificationUri) {
     throw new Error("Device authorization response was missing required fields.");
   }
@@ -142,8 +141,7 @@ export async function startDeviceAuthorization(
         : undefined,
     expiresIn:
       typeof payload.expires_in === "number" && payload.expires_in > 0 ? payload.expires_in : 600,
-    interval:
-      typeof payload.interval === "number" && payload.interval >= 0 ? payload.interval : 5,
+    interval: typeof payload.interval === "number" && payload.interval >= 0 ? payload.interval : 5,
   };
 }
 
@@ -205,7 +203,9 @@ export async function refreshDeviceAuthorization(
   options?: { config?: DeviceAuthConfig; fetchImpl?: typeof fetch },
 ): Promise<DeviceAuthorizationTokens> {
   if (!credentials.refresh_token?.trim()) {
-    throw new Error("Stored device credentials cannot be refreshed because no refresh token exists.");
+    throw new Error(
+      "Stored device credentials cannot be refreshed because no refresh token exists.",
+    );
   }
 
   const config = options?.config ?? resolveDeviceAuthConfig();

--- a/src/auth/providers.ts
+++ b/src/auth/providers.ts
@@ -1,8 +1,8 @@
 import { hint, info, warn, writeStderr } from "../cli-ui.ts";
-import { promptHidden } from "../prompt.ts";
-import { Spinner } from "../spinner.ts";
 import { validateEmbeddingApiKey } from "../embeddings/validate.ts";
 import { promptConfirm } from "../installer/prompt.ts";
+import { promptHidden } from "../prompt.ts";
+import { Spinner } from "../spinner.ts";
 import {
   openBrowserForDeviceLogin,
   pollDeviceAuthorization,
@@ -47,7 +47,9 @@ async function resolveAuthMode(options: AuthenticateOptions): Promise<AuthMode> 
   return useDevice ? "device_code" : "api_key";
 }
 
-async function authenticateWithApiKey(options: AuthenticateOptions): Promise<AuthenticatedCredentials> {
+async function authenticateWithApiKey(
+  options: AuthenticateOptions,
+): Promise<AuthenticatedCredentials> {
   const apiKey = options.apiKey ?? (await promptApiKey());
   if (!options.skipValidation) {
     const spinner = new Spinner("Validating API key");
@@ -75,7 +77,10 @@ async function authenticateWithDeviceCode(
   if (options.interactive) {
     const shouldOpenBrowser =
       process.env.MIRU_OPEN_BROWSER === undefined || process.env.MIRU_OPEN_BROWSER === "1";
-    if (shouldOpenBrowser && openBrowserForDeviceLogin(start.verificationUriComplete ?? start.verificationUri)) {
+    if (
+      shouldOpenBrowser &&
+      openBrowserForDeviceLogin(start.verificationUriComplete ?? start.verificationUri)
+    ) {
       hint("Opened the verification page in your browser.");
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -508,8 +508,7 @@ async function runCli(argv: string[]): Promise<void> {
       profile: args.profile,
     });
     if (newlySaved) {
-      const offerInstall =
-        canPromptForCredentials() && !args.apiKey && !args.device && !args.force;
+      const offerInstall = canPromptForCredentials() && !args.apiKey && !args.device && !args.force;
       if (offerInstall) {
         const install = await promptConfirm("Configure Miru in your coding agent now?");
         if (install) {

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,19 +1,16 @@
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { hasTakaraApiKeyInEnv, normalizeTakaraApiKeyEnv } from "./env.ts";
-import {
-  deviceCredentialsNeedRefresh,
-  refreshDeviceAuthorization,
-} from "./auth/device.ts";
+import { deviceCredentialsNeedRefresh, refreshDeviceAuthorization } from "./auth/device.ts";
 import {
   CREDENTIALS_VERSION,
+  credentialAccessToken,
   LEGACY_CREDENTIALS_VERSION,
   type LegacyStoredCredentials,
   type SaveStoredCredentialsInput,
   type StoredCredentials,
   type StoredSageMakerCredentials,
-  credentialAccessToken,
 } from "./auth/types.ts";
+import { hasTakaraApiKeyInEnv, normalizeTakaraApiKeyEnv } from "./env.ts";
 
 const CREDENTIALS_FILENAME = "credentials.json";
 let activeStoredToken: string | null = null;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,15 @@
 import { authenticateWithProvider } from "./auth/providers.ts";
 import { credentialAccessToken } from "./auth/types.ts";
-import { divider, fail, hint, info, printBrandBanner, success, writeStderr, writeStdout } from "./cli-ui.ts";
+import {
+  divider,
+  fail,
+  hint,
+  info,
+  printBrandBanner,
+  success,
+  writeStderr,
+  writeStdout,
+} from "./cli-ui.ts";
 import {
   beginModeSwitch,
   clearStoredCredentials,
@@ -154,7 +163,9 @@ export async function runSageMakerSetup(options: RunSetupOptions = {}): Promise<
   writeStdout("Miru will connect directly to your self-hosted SageMaker embedding endpoint.");
   hint("Miru only inherits AWS credentials from a profile you've already configured —");
   hint("it never creates or writes to ~/.aws. Run `aws configure --profile <name>` first.");
-  hint("This replaces any stored Takara credentials — only one embedding mode is active at a time.");
+  hint(
+    "This replaces any stored Takara credentials — only one embedding mode is active at a time.",
+  );
   writeStdout("");
 
   const arnInput = options.sagemakerArn ?? (await promptSageMakerArn());
@@ -224,7 +235,9 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
       return { path: saved, newlySaved: true };
     }
     if (stored) {
-      info(`Credentials already configured (env + ${path}). Use --force to replace stored credentials.`);
+      info(
+        `Credentials already configured (env + ${path}). Use --force to replace stored credentials.`,
+      );
       return { path, newlySaved: false };
     }
     info("API key already set via environment variable. Stored credentials unchanged.");
@@ -246,7 +259,9 @@ export async function runSetup(options: RunSetupOptions = {}): Promise<RunSetupR
   divider("─", 48, process.stderr);
   writeStderr("Miru needs Takara credentials for code embeddings.");
   hint("Device code login is the default. Manual API key entry is still available.");
-  hint("This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.");
+  hint(
+    "This replaces any stored SageMaker endpoint — only one embedding mode is active at a time.",
+  );
   writeStderr("");
 
   await beginModeSwitch("takara");

--- a/tests/credentials.test.ts
+++ b/tests/credentials.test.ts
@@ -265,7 +265,7 @@ describe("credentials", () => {
     const path = join(credDir, "credentials.json");
     await Bun.write(
       path,
-      JSON.stringify(
+      `${JSON.stringify(
         {
           version: CREDENTIALS_VERSION,
           kind: "device_code",
@@ -274,7 +274,7 @@ describe("credentials", () => {
         },
         null,
         2,
-      ) + "\n",
+      )}\n`,
     );
     await chmod(path, 0o600);
     expect(await readStoredCredentials()).toBeNull();
@@ -287,7 +287,7 @@ describe("credentials", () => {
     const path = join(credDir, "credentials.json");
     await Bun.write(
       path,
-      JSON.stringify(
+      `${JSON.stringify(
         {
           version: CREDENTIALS_VERSION,
           kind: "device_code",
@@ -296,7 +296,7 @@ describe("credentials", () => {
         },
         null,
         2,
-      ) + "\n",
+      )}\n`,
     );
     await chmod(path, 0o600);
 

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadStoredCredentials, readStoredCredentials, saveStoredCredentials } from "../src/credentials.ts";
+import {
+  loadStoredCredentials,
+  readStoredCredentials,
+  saveStoredCredentials,
+} from "../src/credentials.ts";
 import { TAKARA_API_KEY_ENV } from "../src/env.ts";
 import {
   canPromptForCredentials,
@@ -248,7 +252,7 @@ describe("setup credentials", () => {
     process.env.MIRU_OPEN_BROWSER = "0";
 
     let call = 0;
-    globalThis.fetch = (async (input) => {
+    globalThis.fetch = (async (_input) => {
       call++;
       if (call === 1) {
         return new Response(
@@ -290,7 +294,9 @@ describe("setup credentials", () => {
     }
 
     expect(process.env.TAKARA_API_KEY).toBe("device-access-token");
-    expect(stdout).not.toMatch(/Takara credentials|device-code|Open https:\/\/verify|Saved credentials/i);
+    expect(stdout).not.toMatch(
+      /Takara credentials|device-code|Open https:\/\/verify|Saved credentials/i,
+    );
   });
 
   test("ensureCredentials falls back to re-auth when refresh fails and interactive login is allowed", async () => {
@@ -333,7 +339,9 @@ describe("setup credentials", () => {
         );
       }
       expect(String(input)).toBe("https://auth.example.test/oauth/token");
-      expect(String(init?.body)).toContain("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code");
+      expect(String(init?.body)).toContain(
+        "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
+      );
       return new Response(
         JSON.stringify({
           access_token: "reauth-token",


### PR DESCRIPTION
## Describe your changes
What was changed and why this change was needed

- **What**:
  -  formatting for linting workflows
  -  bun run lint passes.
  -  No logic changes, just formatting

File | Why
-- | --
tests/credentials.test.ts | Template-literal fix (plan)
tests/setup.test.ts | Line wrapping (plan)
.claude-plugin/plugin.json | Format-only (Biome)
plugin.json | Format-only (Biome)
src/auth/device.ts | Format-only (Biome)
src/auth/providers.ts | Format-only (Biome)
src/cli.ts | Format-only (Biome)
src/credentials.ts | Format-only (Biome)
src/setup.ts | Format-only (Biome)

- **Why**:
  - https://github.com/takara-ai/miru-code/actions/runs/31170244844 fails due to linting check

## Issue ticket number and link
ref: PRD-413
https://linear.app/takara-ai/issue/PRD-413/fix-biome-flagged-formatting-errors

## Checklist before requesting a review
- [x] PR title follows conventional commit format (e.g., `feat: add user authentication`, `fix: resolve API timeout`)
- [x] I have performed a self-review of my code
- [x] Tests pass
- [ ] Documentation updated if needed
