### PR TITLE
fix(ci): use Bun-native prepare for prek hooks on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grammars",
     "tokenizer",
     "docs",
+    "scripts/install-git-hooks.ts",
     "README.md",
     "LICENSE"
   ],
@@ -52,7 +53,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "prepare": "command -v prek >/dev/null 2>&1 && prek install --install-hooks || echo 'prek not found; skipping git hook install (see CONTRIBUTING.md)'",
+    "prepare": "bun run scripts/install-git-hooks.ts",
     "vendor-grammars": "bun run scripts/vendor-grammars.ts",
     "prepublishOnly": "bun run vendor-grammars && bun run typecheck && bun test",
     "benchmark:ab": "bun run scripts/search-ab-local.ts",

--- a/scripts/install-git-hooks.ts
+++ b/scripts/install-git-hooks.ts
@@ -1,0 +1,29 @@
+/**
+ * package.json `prepare` — wire prek git hooks when developing from a clone.
+ * Bun-native (no shell redirects) so `bun install` works on Windows CI.
+ *
+ * Skips when not a git checkout or `prek` is missing from PATH.
+ */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+if (!existsSync(join(root, ".git"))) {
+  process.exit(0);
+}
+
+const prek = Bun.which("prek");
+if (!prek) {
+  console.log("prek not found; skipping git hook install (see CONTRIBUTING.md)");
+  process.exit(0);
+}
+
+const result = Bun.spawnSync([prek, "install", "--install-hooks"], {
+  cwd: root,
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+process.exit(result.exitCode === 0 ? 0 : (result.exitCode ?? 1));


### PR DESCRIPTION
## Summary
- Windows CI failed at `bun install` because package `prepare` used shell redirects (`command -v … 2>&1`) that Bun cannot parse on Windows
- Replace with a Bun-native script using `Bun.which` + `Bun.spawnSync`; skip cleanly without git or without `prek`
- Ship the script in package `files` so published installs still resolve `prepare`

## Test plan
- [x] `bun run prepare` exits 0 without prek
- [ ] CI green on `main` including `test (windows-latest)` Install step