### PR TITLE
feat(installer): enable STE skill on all Miru IDEs (ref PRD-405)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,19 @@ miru uninstall   # remove miru config
 **Supported:** Cursor · Claude Code · Gemini CLI · Kiro · OpenCode · GitHub Copilot · Codex · VS Code · Visual Studio (Windows) · Windsurf / Devin Desktop
 
 
-| IDE            | MCP                                   | Instructions / rules            | Hooks *(experimental)*                            | Caveman *(experimental)*                            | STE *(experimental)*            |
-| -------------- | ------------------------------------- | ------------------------------- | ------------------------------------------------- | --------------------------------------------------- | ------------------------------- |
-| Cursor         | `~/.cursor/mcp.json`                  | `~/.cursor/rules/miru-code.mdc` | `~/.cursor/hooks.json`                            | `~/.agents/skills/caveman/SKILL.md`                 | `~/.cursor/skills/ste/SKILL.md` |
-| Claude Code    | `~/.claude.json`                      | `~/.claude/CLAUDE.md`           | `~/.claude/settings.json`                         | `~/.claude/skills/caveman/SKILL.md`                 | `~/.claude/skills/ste/SKILL.md` |
-| Gemini CLI     | `~/.gemini/settings.json`             | `~/.gemini/GEMINI.md`           | `~/.gemini/settings.json` (`BeforeTool`)          | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
-| Kiro           | `~/.kiro/settings/mcp.json`           | `~/.kiro/steering/miru.md`      | `~/.kiro/settings/hooks.json`                     | `~/.kiro/skills/caveman/SKILL.md`                   | —                               |
-| OpenCode       | `$XDG_CONFIG_HOME/opencode/opencode.json(c)` *(else `~/.config/opencode/…`)* | `…/AGENTS.md` | `…/plugins/miru-search-guard.ts` | `~/.agents/skills/caveman/SKILL.md` | — |
-| GitHub Copilot | `~/.copilot/mcp-config.json`          | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
-| Codex          | `~/.codex/config.toml`                | `~/.codex/AGENTS.md`            | `~/.codex/hooks.json`                             | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
-| VS Code        | `…/Code/User/mcp.json`                | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
-| Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
-| Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
+| IDE            | MCP                                   | Instructions / rules            | Hooks *(experimental)*                            | Caveman *(experimental)*                            | STE *(experimental)*                         |
+| -------------- | ------------------------------------- | ------------------------------- | ------------------------------------------------- | --------------------------------------------------- | -------------------------------------------- |
+| Cursor         | `~/.cursor/mcp.json`                  | `~/.cursor/rules/miru-code.mdc` | `~/.cursor/hooks.json`                            | `~/.agents/skills/caveman/SKILL.md`                 | `~/.cursor/skills/ste/SKILL.md`              |
+| Claude Code    | `~/.claude.json`                      | `~/.claude/CLAUDE.md`           | `~/.claude/settings.json`                         | `~/.claude/skills/caveman/SKILL.md`                 | `~/.claude/skills/ste/SKILL.md`              |
+| Gemini CLI     | `~/.gemini/settings.json`             | `~/.gemini/GEMINI.md`           | `~/.gemini/settings.json` (`BeforeTool`)          | `~/.agents/skills/caveman/SKILL.md`                 | `~/.gemini/skills/ste/SKILL.md`              |
+| Kiro           | `~/.kiro/settings/mcp.json`           | `~/.kiro/steering/miru.md`      | `~/.kiro/settings/hooks.json`                     | `~/.kiro/skills/caveman/SKILL.md`                   | `~/.kiro/skills/ste/SKILL.md`                |
+| OpenCode       | `$XDG_CONFIG_HOME/opencode/opencode.json(c)` *(else `~/.config/opencode/…`)* | `…/AGENTS.md` | `…/plugins/miru-search-guard.ts` | `~/.agents/skills/caveman/SKILL.md` | `…/skills/ste/SKILL.md` |
+| GitHub Copilot | `~/.copilot/mcp-config.json`          | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.copilot/skills/ste/SKILL.md`             |
+| Codex          | `~/.codex/config.toml`                | `~/.codex/AGENTS.md`            | `~/.codex/hooks.json`                             | `~/.agents/skills/caveman/SKILL.md`                 | `~/.codex/skills/ste/SKILL.md`               |
+| VS Code        | `…/Code/User/mcp.json`                | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.copilot/skills/ste/SKILL.md`             |
+| Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.copilot/skills/ste/SKILL.md`             |
+| Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  | `~/.agents/skills/caveman/SKILL.md`                 | `~/.codeium/windsurf/skills/ste/SKILL.md`    |
+
 
 ### Plugin packaging
 
@@ -98,7 +99,7 @@ Current limitation:
 
 ### Search hooks
 
-Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet. Caveman is an on-demand Agent Skill (default off): invoke with `/caveman` or “talk like caveman”; stop with “normal mode”. Invocation UI varies by IDE (`/caveman`, `$caveman`, `@caveman`, etc.). Most IDEs share `~/.agents/skills/caveman/SKILL.md` (including Copilot / VS Code / Visual Studio); Claude Code and Kiro keep vendor-native skill dirs. Ownership is tracked on the shared path so uninstalling one IDE keeps the skill while another still owns it; selecting all owners removes it once. STE is an on-demand Agent Skill (default off): invoke with `/ste` or “de-slop this”; keep articles and complete sentences.
+Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet. Caveman is an on-demand Agent Skill (default off): invoke with `/caveman` or “talk like caveman”; stop with “normal mode”. Invocation UI varies by IDE (`/caveman`, `$caveman`, `@caveman`, etc.). Most IDEs share `~/.agents/skills/caveman/SKILL.md` (including Copilot / VS Code / Visual Studio); Claude Code and Kiro keep vendor-native skill dirs. Ownership is tracked on the shared path so uninstalling one IDE keeps the skill while another still owns it; selecting all owners removes it once. STE is an on-demand Agent Skill (default off): invoke with `/ste` or “de-slop this”; keep articles and complete sentences. Invocation UI varies by IDE. Copilot / VS Code / Visual Studio share `~/.copilot/skills/ste/`.
 
 <details>
 <summary>STE writing <em>(experimental)</em></summary>
@@ -107,7 +108,7 @@ STE helps write **clear technical English** for docs, runbooks, errors, and rele
 
 **Not ASD-certified.** Full dictionary compliance needs the official standard at [asd-ste100.org](https://www.asd-ste100.org). Miru does not ship the copyrighted ASD dictionary.
 
-Not for marketing or brand copy. Off by default; enable STE in the installer for Cursor and/or Claude Code.
+Not for marketing or brand copy. Off by default; enable STE in the installer for any supported IDE. Restart the IDE (or reload skills) after install. Codex may require its skills feature enabled in `~/.codex/config.toml`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Interactive TUI — **↑↓** move, **space** toggle, **a** all, **enter** conf
 | Cursor rules                  | Always-on `.cursor/rules/miru-code.mdc` (Cursor only)               |
 | Search hooks *(experimental)* | Block built-in Grep/Glob and redirect to Miru MCP                   |
 | Caveman *(experimental)*      | On-demand chat compression skill (`/caveman`)                       |
+| STE writing *(experimental)*  | On-demand clear technical English for docs (`/ste`)                 |
 
 
 Restart the IDE when done.
@@ -68,18 +69,18 @@ miru uninstall   # remove miru config
 **Supported:** Cursor · Claude Code · Gemini CLI · Kiro · OpenCode · GitHub Copilot · Codex · VS Code · Visual Studio (Windows) · Windsurf / Devin Desktop
 
 
-| IDE            | MCP                                   | Instructions / rules            | Hooks *(experimental)*                            | Caveman *(experimental)*                            |
-| -------------- | ------------------------------------- | ------------------------------- | ------------------------------------------------- | --------------------------------------------------- |
-| Cursor         | `~/.cursor/mcp.json`                  | `~/.cursor/rules/miru-code.mdc` | `~/.cursor/hooks.json`                            | `~/.agents/skills/caveman/SKILL.md`                 |
-| Claude Code    | `~/.claude.json`                      | `~/.claude/CLAUDE.md`           | `~/.claude/settings.json`                         | `~/.claude/skills/caveman/SKILL.md`                 |
-| Gemini CLI     | `~/.gemini/settings.json`             | `~/.gemini/GEMINI.md`           | `~/.gemini/settings.json` (`BeforeTool`)          | `~/.agents/skills/caveman/SKILL.md`                 |
-| Kiro           | `~/.kiro/settings/mcp.json`           | `~/.kiro/steering/miru.md`      | `~/.kiro/settings/hooks.json`                     | `~/.kiro/skills/caveman/SKILL.md`                   |
-| OpenCode       | `$XDG_CONFIG_HOME/opencode/opencode.json(c)` *(else `~/.config/opencode/…`)* | `…/AGENTS.md` | `…/plugins/miru-search-guard.ts` | `~/.agents/skills/caveman/SKILL.md` |
-| GitHub Copilot | `~/.copilot/mcp-config.json`          | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 |
-| Codex          | `~/.codex/config.toml`                | `~/.codex/AGENTS.md`            | `~/.codex/hooks.json`                             | `~/.agents/skills/caveman/SKILL.md`                 |
-| VS Code        | `…/Code/User/mcp.json`                | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 |
-| Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 |
-| Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  | `~/.agents/skills/caveman/SKILL.md`                 |
+| IDE            | MCP                                   | Instructions / rules            | Hooks *(experimental)*                            | Caveman *(experimental)*                            | STE *(experimental)*            |
+| -------------- | ------------------------------------- | ------------------------------- | ------------------------------------------------- | --------------------------------------------------- | ------------------------------- |
+| Cursor         | `~/.cursor/mcp.json`                  | `~/.cursor/rules/miru-code.mdc` | `~/.cursor/hooks.json`                            | `~/.agents/skills/caveman/SKILL.md`                 | `~/.cursor/skills/ste/SKILL.md` |
+| Claude Code    | `~/.claude.json`                      | `~/.claude/CLAUDE.md`           | `~/.claude/settings.json`                         | `~/.claude/skills/caveman/SKILL.md`                 | `~/.claude/skills/ste/SKILL.md` |
+| Gemini CLI     | `~/.gemini/settings.json`             | `~/.gemini/GEMINI.md`           | `~/.gemini/settings.json` (`BeforeTool`)          | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
+| Kiro           | `~/.kiro/settings/mcp.json`           | `~/.kiro/steering/miru.md`      | `~/.kiro/settings/hooks.json`                     | `~/.kiro/skills/caveman/SKILL.md`                   | —                               |
+| OpenCode       | `$XDG_CONFIG_HOME/opencode/opencode.json(c)` *(else `~/.config/opencode/…`)* | `…/AGENTS.md` | `…/plugins/miru-search-guard.ts` | `~/.agents/skills/caveman/SKILL.md` | — |
+| GitHub Copilot | `~/.copilot/mcp-config.json`          | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
+| Codex          | `~/.codex/config.toml`                | `~/.codex/AGENTS.md`            | `~/.codex/hooks.json`                             | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
+| VS Code        | `…/Code/User/mcp.json`                | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
+| Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
+| Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  | `~/.agents/skills/caveman/SKILL.md`                 | —                               |
 
 ### Plugin packaging
 
@@ -97,7 +98,18 @@ Current limitation:
 
 ### Search hooks
 
-Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet. Caveman is an on-demand Agent Skill (default off): invoke with `/caveman` or “talk like caveman”; stop with “normal mode”. Invocation UI varies by IDE (`/caveman`, `$caveman`, `@caveman`, etc.). Most IDEs share `~/.agents/skills/caveman/SKILL.md` (including Copilot / VS Code / Visual Studio); Claude Code and Kiro keep vendor-native skill dirs. Ownership is tracked on the shared path so uninstalling one IDE keeps the skill while another still owns it; selecting all owners removes it once.
+Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet. Caveman is an on-demand Agent Skill (default off): invoke with `/caveman` or “talk like caveman”; stop with “normal mode”. Invocation UI varies by IDE (`/caveman`, `$caveman`, `@caveman`, etc.). Most IDEs share `~/.agents/skills/caveman/SKILL.md` (including Copilot / VS Code / Visual Studio); Claude Code and Kiro keep vendor-native skill dirs. Ownership is tracked on the shared path so uninstalling one IDE keeps the skill while another still owns it; selecting all owners removes it once. STE is an on-demand Agent Skill (default off): invoke with `/ste` or “de-slop this”; keep articles and complete sentences.
+
+<details>
+<summary>STE writing <em>(experimental)</em></summary>
+
+STE helps write **clear technical English** for docs, runbooks, errors, and release notes (pragmatic ASD-STE100-inspired rules). Invoke with `/ste` or “de-slop this”. Keep articles and complete sentences — not telegraph-style omission.
+
+**Not ASD-certified.** Full dictionary compliance needs the official standard at [asd-ste100.org](https://www.asd-ste100.org). Miru does not ship the copyrighted ASD dictionary.
+
+Not for marketing or brand copy. Off by default; enable STE in the installer for Cursor and/or Claude Code.
+
+</details>
 
 <details>
 <summary>Caveman mode <em>(experimental)</em></summary>

--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ miru uninstall   # remove miru config
 
 | IDE            | MCP                                   | Instructions / rules            | Hooks *(experimental)*                            | Caveman *(experimental)*                            | STE *(experimental)*                         |
 | -------------- | ------------------------------------- | ------------------------------- | ------------------------------------------------- | --------------------------------------------------- | -------------------------------------------- |
-| Cursor         | `~/.cursor/mcp.json`                  | `~/.cursor/rules/miru-code.mdc` | `~/.cursor/hooks.json`                            | `~/.agents/skills/caveman/SKILL.md`                 | `~/.cursor/skills/ste/SKILL.md`              |
+| Cursor         | `~/.cursor/mcp.json`                  | `~/.cursor/rules/miru-code.mdc` | `~/.cursor/hooks.json`                            | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
 | Claude Code    | `~/.claude.json`                      | `~/.claude/CLAUDE.md`           | `~/.claude/settings.json`                         | `~/.claude/skills/caveman/SKILL.md`                 | `~/.claude/skills/ste/SKILL.md`              |
-| Gemini CLI     | `~/.gemini/settings.json`             | `~/.gemini/GEMINI.md`           | `~/.gemini/settings.json` (`BeforeTool`)          | `~/.agents/skills/caveman/SKILL.md`                 | `~/.gemini/skills/ste/SKILL.md`              |
+| Gemini CLI     | `~/.gemini/settings.json`             | `~/.gemini/GEMINI.md`           | `~/.gemini/settings.json` (`BeforeTool`)          | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
 | Kiro           | `~/.kiro/settings/mcp.json`           | `~/.kiro/steering/miru.md`      | `~/.kiro/settings/hooks.json`                     | `~/.kiro/skills/caveman/SKILL.md`                   | `~/.kiro/skills/ste/SKILL.md`                |
-| OpenCode       | `$XDG_CONFIG_HOME/opencode/opencode.json(c)` *(else `~/.config/opencode/…`)* | `…/AGENTS.md` | `…/plugins/miru-search-guard.ts` | `~/.agents/skills/caveman/SKILL.md` | `…/skills/ste/SKILL.md` |
-| GitHub Copilot | `~/.copilot/mcp-config.json`          | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.copilot/skills/ste/SKILL.md`             |
-| Codex          | `~/.codex/config.toml`                | `~/.codex/AGENTS.md`            | `~/.codex/hooks.json`                             | `~/.agents/skills/caveman/SKILL.md`                 | `~/.codex/skills/ste/SKILL.md`               |
-| VS Code        | `…/Code/User/mcp.json`                | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.copilot/skills/ste/SKILL.md`             |
-| Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.copilot/skills/ste/SKILL.md`             |
-| Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  | `~/.agents/skills/caveman/SKILL.md`                 | `~/.codeium/windsurf/skills/ste/SKILL.md`    |
+| OpenCode       | `$XDG_CONFIG_HOME/opencode/opencode.json(c)` *(else `~/.config/opencode/…`)* | `…/AGENTS.md` | `…/plugins/miru-search-guard.ts` | `~/.agents/skills/caveman/SKILL.md` | `~/.agents/skills/ste/SKILL.md` |
+| GitHub Copilot | `~/.copilot/mcp-config.json`          | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
+| Codex          | `~/.codex/config.toml`                | `~/.codex/AGENTS.md`            | `~/.codex/hooks.json`                             | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
+| VS Code        | `…/Code/User/mcp.json`                | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
+| Visual Studio  | `%USERPROFILE%\.mcp.json`             | —                               | `~/.copilot/hooks/miru-search.json`               | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
+| Windsurf       | —                                     | —                               | `~/.codeium/windsurf/hooks.json`                  | `~/.agents/skills/caveman/SKILL.md`                 | `~/.agents/skills/ste/SKILL.md`              |
 
 
 ### Plugin packaging
@@ -99,7 +99,7 @@ Current limitation:
 
 ### Search hooks
 
-Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet. Caveman is an on-demand Agent Skill (default off): invoke with `/caveman` or “talk like caveman”; stop with “normal mode”. Invocation UI varies by IDE (`/caveman`, `$caveman`, `@caveman`, etc.). Most IDEs share `~/.agents/skills/caveman/SKILL.md` (including Copilot / VS Code / Visual Studio); Claude Code and Kiro keep vendor-native skill dirs. Ownership is tracked on the shared path so uninstalling one IDE keeps the skill while another still owns it; selecting all owners removes it once. STE is an on-demand Agent Skill (default off): invoke with `/ste` or “de-slop this”; keep articles and complete sentences. Invocation UI varies by IDE. Copilot / VS Code / Visual Studio share `~/.copilot/skills/ste/`.
+Sub-agent files are also written where supported (see `miru install` plan). Windsurf hooks only *(experimental)* — no MCP entry yet. Caveman is an on-demand Agent Skill (default off): invoke with `/caveman` or “talk like caveman”; stop with “normal mode”. Invocation UI varies by IDE (`/caveman`, `$caveman`, `@caveman`, etc.). Most IDEs share `~/.agents/skills/caveman/SKILL.md` (including Copilot / VS Code / Visual Studio); Claude Code and Kiro keep vendor-native skill dirs. Ownership is tracked on the shared path so uninstalling one IDE keeps the skill while another still owns it; selecting all owners removes it once. STE is an on-demand Agent Skill (default off): invoke with `/ste` or “de-slop this”; keep articles and complete sentences. Most IDEs share `~/.agents/skills/ste/` the same way (ownership via `miru-owners.json`); Claude Code and Kiro keep vendor-native STE dirs.
 
 <details>
 <summary>STE writing <em>(experimental)</em></summary>
@@ -108,7 +108,7 @@ STE helps write **clear technical English** for docs, runbooks, errors, and rele
 
 **Not ASD-certified.** Full dictionary compliance needs the official standard at [asd-ste100.org](https://www.asd-ste100.org). Miru does not ship the copyrighted ASD dictionary.
 
-Not for marketing or brand copy. Off by default; enable STE in the installer for any supported IDE. Restart the IDE (or reload skills) after install. Codex may require its skills feature enabled in `~/.codex/config.toml`.
+Not for marketing or brand copy. Off by default; enable STE in the installer for any supported IDE. Restart the IDE (or reload skills) after install. For Codex, install also sets `[features] skills = true` in `~/.codex/config.toml` (same as Caveman).
 
 </details>
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -178,18 +178,21 @@ export function printCommandHelp(command: string): void {
     case "install":
       commandHeader("install", "Interactive global agent setup.");
       writeStdout("Configures MCP server, instructions, sub-agent files, and optional");
-      writeStdout("experimental integrations (search hooks, Caveman skill) under");
+      writeStdout("experimental integrations (search hooks, Caveman, STE writing) under");
       writeStdout("your user config (~/.claude, ~/.cursor, etc.).");
       writeStdout("");
-      writeStdout("Caveman = on-demand chat compression (/caveman). Off by default.");
-      writeStdout("Supported on all Miru installer IDEs (shared Copilot path for VS Code / VS).");
+      writeStdout(
+        "Caveman = chat compression (/caveman). STE = clear docs (/ste). Off by default.",
+      );
+      writeStdout("Caveman is supported on all Miru installer IDEs (shared path for most IDEs).");
+      writeStdout("STE is available for Cursor and Claude Code.");
       writeStdout("Run miru setup first, or set TAKARA_API_KEY for MCP env expansion.");
       writeStdout("");
       return;
     case "uninstall":
       commandHeader("uninstall", "Remove miru configuration from agents.");
       writeStdout("Removes MCP entries, marked instruction blocks, global sub-agents,");
-      writeStdout("and selected optional integrations (hooks, Caveman skill).");
+      writeStdout("and selected optional integrations (hooks, Caveman, STE skills).");
       writeStdout("Also deletes the global benchmark report from Miru's state directory.");
       writeStdout("");
       return;

--- a/src/help.ts
+++ b/src/help.ts
@@ -185,7 +185,9 @@ export function printCommandHelp(command: string): void {
         "Caveman = chat compression (/caveman). STE = clear docs (/ste). Off by default.",
       );
       writeStdout("Caveman is supported on all Miru installer IDEs (shared path for most IDEs).");
-      writeStdout("STE is supported on all Miru installer IDEs (same shared-path ownership model).");
+      writeStdout(
+        "STE is supported on all Miru installer IDEs (same shared-path ownership model).",
+      );
       writeStdout("Run miru setup first, or set TAKARA_API_KEY for MCP env expansion.");
       writeStdout("");
       return;

--- a/src/help.ts
+++ b/src/help.ts
@@ -185,7 +185,7 @@ export function printCommandHelp(command: string): void {
         "Caveman = chat compression (/caveman). STE = clear docs (/ste). Off by default.",
       );
       writeStdout("Caveman is supported on all Miru installer IDEs (shared path for most IDEs).");
-      writeStdout("STE is available for Cursor and Claude Code.");
+      writeStdout("STE skill installs for all Miru installer IDEs (shared Copilot path for VS Code / VS).");
       writeStdout("Run miru setup first, or set TAKARA_API_KEY for MCP env expansion.");
       writeStdout("");
       return;

--- a/src/help.ts
+++ b/src/help.ts
@@ -185,7 +185,7 @@ export function printCommandHelp(command: string): void {
         "Caveman = chat compression (/caveman). STE = clear docs (/ste). Off by default.",
       );
       writeStdout("Caveman is supported on all Miru installer IDEs (shared path for most IDEs).");
-      writeStdout("STE skill installs for all Miru installer IDEs (shared Copilot path for VS Code / VS).");
+      writeStdout("STE is supported on all Miru installer IDEs (same shared-path ownership model).");
       writeStdout("Run miru setup first, or set TAKARA_API_KEY for MCP env expansion.");
       writeStdout("");
       return;

--- a/src/installer/agents.ts
+++ b/src/installer/agents.ts
@@ -14,16 +14,21 @@ export function copilotHomeDir(home: string): string {
   return join(home, ".copilot");
 }
 
-/** Shared Copilot / VS Code / Visual Studio STE skill directory. */
-function copilotSteSkillDir(home: string): string {
-  return join(copilotHomeDir(home), "skills", "ste");
+/**
+ * Vendors that do not scan `~/.agents/skills/` and need a native skill dir
+ * (Caveman + STE).
+ */
+export type NativeSkillVendor = "claude" | "kiro";
+
+/** @deprecated Use NativeSkillVendor. */
+export type NativeCavemanVendor = NativeSkillVendor;
+
+function skillMd(home: string, rootDir: string, skillName: string): string {
+  return join(home, rootDir, "skills", skillName, "SKILL.md");
 }
 
-/** Vendors that do not scan `~/.agents/skills/` and need a native skill dir. */
-export type NativeCavemanVendor = "claude" | "kiro";
-
-function cavemanSkillMd(home: string, rootDir: string): string {
-  return join(home, rootDir, "skills", "caveman", "SKILL.md");
+function skillDir(home: string, rootDir: string, skillName: string): string {
+  return join(home, rootDir, "skills", skillName);
 }
 
 /**
@@ -32,12 +37,22 @@ function cavemanSkillMd(home: string, rootDir: string): string {
  * Claude Code and Kiro still use vendor-native skill dirs.
  */
 export function agentsCavemanSkillPath(home: string): string {
-  return cavemanSkillMd(home, ".agents");
+  return skillMd(home, ".agents", "caveman");
 }
 
 /** Claude Code / Kiro native Caveman skill path. */
-export function nativeCavemanSkillPath(home: string, vendor: NativeCavemanVendor): string {
-  return cavemanSkillMd(home, `.${vendor}`);
+export function nativeCavemanSkillPath(home: string, vendor: NativeSkillVendor): string {
+  return skillMd(home, `.${vendor}`, "caveman");
+}
+
+/** Shared STE skill directory under `~/.agents/skills/ste`. */
+export function agentsSteSkillDir(home: string): string {
+  return skillDir(home, ".agents", "ste");
+}
+
+/** Claude Code / Kiro native STE skill directory. */
+export function nativeSteSkillDir(home: string, vendor: NativeSkillVendor): string {
+  return skillDir(home, `.${vendor}`, "ste");
 }
 
 function kiroHooksPath(home: string): string {
@@ -56,12 +71,6 @@ export function opencodeConfigDir(home: string): string {
 
 function opencodePluginPath(home: string): string {
   return join(opencodeConfigDir(home), "plugins", "miru-search-guard.ts");
-}
-
-function opencodeSteSkillDir(home: string): string {
-  const xdg = process.env.XDG_CONFIG_HOME;
-  const base = xdg ? join(xdg, "opencode") : join(home, ".config", "opencode");
-  return join(base, "skills", "ste");
 }
 
 export type InstallAction =
@@ -138,7 +147,9 @@ export interface AgentTarget {
    * unsupported.
    */
   cavemanSkillPath: string | null;
-  /** On-demand STE skill directory (`…/skills/ste/`). */
+  /**
+   * On-demand STE skill directory (`…/skills/ste/`), or null if unsupported.
+   */
   steSkillDir: string | null;
 }
 
@@ -211,6 +222,7 @@ function jsonMcp(path: string, key: string, entry: Record<string, unknown>): Mcp
 }
 
 const SHARED_CAVEMAN_SKILL = agentsCavemanSkillPath(HOME);
+const SHARED_STE_SKILL_DIR = agentsSteSkillDir(HOME);
 
 export const AGENT_TARGETS: AgentTarget[] = [
   {
@@ -226,7 +238,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".claude", "agents", "miru-code.md"),
     subagentId: "claude",
     cavemanSkillPath: nativeCavemanSkillPath(HOME, "claude"),
-    steSkillDir: join(HOME, ".claude", "skills", "ste"),
+    steSkillDir: nativeSteSkillDir(HOME, "claude"),
   },
   {
     id: "cursor",
@@ -241,7 +253,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".cursor", "agents", "miru-code.md"),
     subagentId: "cursor",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: join(HOME, ".cursor", "skills", "ste"),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "gemini",
@@ -256,7 +268,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".gemini", "agents", "miru-code.md"),
     subagentId: "gemini",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: join(HOME, ".gemini", "skills", "ste"),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "kiro",
@@ -271,7 +283,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".kiro", "agents", "miru-code.md"),
     subagentId: "kiro",
     cavemanSkillPath: nativeCavemanSkillPath(HOME, "kiro"),
-    steSkillDir: join(HOME, ".kiro", "skills", "ste"),
+    steSkillDir: nativeSteSkillDir(HOME, "kiro"),
   },
   {
     id: "opencode",
@@ -286,7 +298,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(opencodeConfigDir(HOME), "agents", "miru-code.md"),
     subagentId: "opencode",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: opencodeSteSkillDir(HOME),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "copilot",
@@ -305,7 +317,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(copilotHomeDir(HOME), "agents", "miru-code.agent.md"),
     subagentId: "copilot",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: copilotSteSkillDir(HOME),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "codex",
@@ -326,7 +338,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: join(HOME, ".codex", "skills", "ste"),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "vscode",
@@ -341,7 +353,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: copilotSteSkillDir(HOME),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "windsurf",
@@ -356,7 +368,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: join(HOME, ".codeium", "windsurf", "skills", "ste"),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
   {
     id: "visualstudio",
@@ -371,7 +383,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: copilotSteSkillDir(HOME),
+    steSkillDir: SHARED_STE_SKILL_DIR,
   },
 ];
 

--- a/src/installer/agents.ts
+++ b/src/installer/agents.ts
@@ -14,6 +14,11 @@ export function copilotHomeDir(home: string): string {
   return join(home, ".copilot");
 }
 
+/** Shared Copilot / VS Code / Visual Studio STE skill directory. */
+function copilotSteSkillDir(home: string): string {
+  return join(copilotHomeDir(home), "skills", "ste");
+}
+
 /** Vendors that do not scan `~/.agents/skills/` and need a native skill dir. */
 export type NativeCavemanVendor = "claude" | "kiro";
 
@@ -51,6 +56,12 @@ export function opencodeConfigDir(home: string): string {
 
 function opencodePluginPath(home: string): string {
   return join(opencodeConfigDir(home), "plugins", "miru-search-guard.ts");
+}
+
+function opencodeSteSkillDir(home: string): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const base = xdg ? join(xdg, "opencode") : join(home, ".config", "opencode");
+  return join(base, "skills", "ste");
 }
 
 export type InstallAction =
@@ -127,7 +138,7 @@ export interface AgentTarget {
    * unsupported.
    */
   cavemanSkillPath: string | null;
-  /** On-demand STE skill directory (`…/skills/ste/`), or null if unsupported. */
+  /** On-demand STE skill directory (`…/skills/ste/`). */
   steSkillDir: string | null;
 }
 
@@ -245,7 +256,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".gemini", "agents", "miru-code.md"),
     subagentId: "gemini",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: join(HOME, ".gemini", "skills", "ste"),
   },
   {
     id: "kiro",
@@ -260,7 +271,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".kiro", "agents", "miru-code.md"),
     subagentId: "kiro",
     cavemanSkillPath: nativeCavemanSkillPath(HOME, "kiro"),
-    steSkillDir: null,
+    steSkillDir: join(HOME, ".kiro", "skills", "ste"),
   },
   {
     id: "opencode",
@@ -275,7 +286,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(opencodeConfigDir(HOME), "agents", "miru-code.md"),
     subagentId: "opencode",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: opencodeSteSkillDir(HOME),
   },
   {
     id: "copilot",
@@ -294,7 +305,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(copilotHomeDir(HOME), "agents", "miru-code.agent.md"),
     subagentId: "copilot",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: copilotSteSkillDir(HOME),
   },
   {
     id: "codex",
@@ -315,7 +326,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: join(HOME, ".codex", "skills", "ste"),
   },
   {
     id: "vscode",
@@ -330,7 +341,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: copilotSteSkillDir(HOME),
   },
   {
     id: "windsurf",
@@ -345,7 +356,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: join(HOME, ".codeium", "windsurf", "skills", "ste"),
   },
   {
     id: "visualstudio",
@@ -360,7 +371,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
-    steSkillDir: null,
+    steSkillDir: copilotSteSkillDir(HOME),
   },
 ];
 

--- a/src/installer/agents.ts
+++ b/src/installer/agents.ts
@@ -127,6 +127,8 @@ export interface AgentTarget {
    * unsupported.
    */
   cavemanSkillPath: string | null;
+  /** On-demand STE skill directory (`…/skills/ste/`), or null if unsupported. */
+  steSkillDir: string | null;
 }
 
 export function opencodeMcpPath(): string {
@@ -213,6 +215,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".claude", "agents", "miru-code.md"),
     subagentId: "claude",
     cavemanSkillPath: nativeCavemanSkillPath(HOME, "claude"),
+    steSkillDir: join(HOME, ".claude", "skills", "ste"),
   },
   {
     id: "cursor",
@@ -227,6 +230,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".cursor", "agents", "miru-code.md"),
     subagentId: "cursor",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: join(HOME, ".cursor", "skills", "ste"),
   },
   {
     id: "gemini",
@@ -241,6 +245,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".gemini", "agents", "miru-code.md"),
     subagentId: "gemini",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
   {
     id: "kiro",
@@ -255,6 +260,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(HOME, ".kiro", "agents", "miru-code.md"),
     subagentId: "kiro",
     cavemanSkillPath: nativeCavemanSkillPath(HOME, "kiro"),
+    steSkillDir: null,
   },
   {
     id: "opencode",
@@ -269,6 +275,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(opencodeConfigDir(HOME), "agents", "miru-code.md"),
     subagentId: "opencode",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
   {
     id: "copilot",
@@ -287,6 +294,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: join(copilotHomeDir(HOME), "agents", "miru-code.agent.md"),
     subagentId: "copilot",
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
   {
     id: "codex",
@@ -307,6 +315,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
   {
     id: "vscode",
@@ -321,6 +330,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
   {
     id: "windsurf",
@@ -335,6 +345,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
   {
     id: "visualstudio",
@@ -349,6 +360,7 @@ export const AGENT_TARGETS: AgentTarget[] = [
     subagentPath: null,
     subagentId: null,
     cavemanSkillPath: SHARED_CAVEMAN_SKILL,
+    steSkillDir: null,
   },
 ];
 

--- a/src/installer/caveman-shared.ts
+++ b/src/installer/caveman-shared.ts
@@ -1,14 +1,14 @@
+import type { AgentTarget, InstallAction } from "./agents.ts";
 import {
   ensureSharedSkillOwnersOnInstall,
   isSharedSkillPath,
   removeSkillMdAndOwners,
   resolveSharedSkillUninstall,
-  SKILL_OWNERS_FILE,
   type SharedSkillCtx,
   type SharedSkillUninstallDecision,
+  SKILL_OWNERS_FILE,
   type SkillPathOf,
 } from "./shared-skill.ts";
-import type { AgentTarget, InstallAction } from "./agents.ts";
 
 /** @deprecated Prefer SKILL_OWNERS_FILE — same sidecar name for all shared skills. */
 export const CAVEMAN_OWNERS_FILE = SKILL_OWNERS_FILE;

--- a/src/installer/caveman-shared.ts
+++ b/src/installer/caveman-shared.ts
@@ -1,161 +1,45 @@
-import { mkdir, rmdir, unlink } from "node:fs/promises";
-import { join } from "node:path";
-import { AGENT_TARGETS, type AgentTarget, type InstallAction, isAgentDetected } from "./agents.ts";
+import {
+  ensureSharedSkillOwnersOnInstall,
+  isSharedSkillPath,
+  removeSkillMdAndOwners,
+  resolveSharedSkillUninstall,
+  SKILL_OWNERS_FILE,
+  type SharedSkillCtx,
+  type SharedSkillUninstallDecision,
+  type SkillPathOf,
+} from "./shared-skill.ts";
+import type { AgentTarget, InstallAction } from "./agents.ts";
 
-export const CAVEMAN_OWNERS_FILE = "miru-owners.json";
+/** @deprecated Prefer SKILL_OWNERS_FILE — same sidecar name for all shared skills. */
+export const CAVEMAN_OWNERS_FILE = SKILL_OWNERS_FILE;
 
 /** Context for shared `~/.agents/skills` Caveman install/uninstall. */
-export interface CavemanSharedCtx {
-  selectedAgents: AgentTarget[];
-  allAgents?: AgentTarget[];
-  isDetected?: (agent: AgentTarget) => Promise<boolean>;
-}
+export type CavemanSharedCtx = SharedSkillCtx;
 
-function uniqueIds(ids: Iterable<string>): string[] {
-  return Array.from(new Set(ids));
-}
+export type SharedCavemanUninstallDecision = SharedSkillUninstallDecision;
 
-function resolvedAgents(ctx: CavemanSharedCtx): AgentTarget[] {
-  return ctx.allAgents ?? AGENT_TARGETS;
-}
-
-function agentsSharingCavemanPath(path: string, allAgents: AgentTarget[]): AgentTarget[] {
-  return allAgents.filter((agent) => agent.cavemanSkillPath === path);
-}
+const cavemanPathOf: SkillPathOf = (agent) => agent.cavemanSkillPath;
 
 export function isSharedCavemanPath(path: string, allAgents: AgentTarget[]): boolean {
-  return agentsSharingCavemanPath(path, allAgents).length > 1;
+  return isSharedSkillPath(path, allAgents, cavemanPathOf);
 }
 
-export async function readCavemanOwners(skillDir: string): Promise<string[] | null> {
-  const ownersPath = join(skillDir, CAVEMAN_OWNERS_FILE);
-  if (!(await Bun.file(ownersPath).exists())) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(await Bun.file(ownersPath).text()) as unknown;
-    if (!Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed.filter((item): item is string => typeof item === "string");
-  } catch {
-    return null;
-  }
-}
-
-export async function writeCavemanOwners(skillDir: string, owners: string[]): Promise<void> {
-  await mkdir(skillDir, { recursive: true });
-  await Bun.write(
-    join(skillDir, CAVEMAN_OWNERS_FILE),
-    `${JSON.stringify([...owners].sort(), null, 2)}\n`,
-  );
-}
-
-/**
- * Stamp shared-path ownership on install.
- * - Existing owners file: add current agent.
- * - Fresh skill: start with current agent only.
- * - Legacy skill (file exists, no owners): seed from detected siblings + current;
- *   skip writing a singleton so uninstall stays on the legacy keep path.
- */
 export async function ensureSharedCavemanOwnersOnInstall(
   skillDir: string,
   skillPath: string,
   agent: AgentTarget,
   ctx: CavemanSharedCtx,
 ): Promise<void> {
-  const existing = await readCavemanOwners(skillDir);
-  if (existing !== null) {
-    await writeCavemanOwners(skillDir, uniqueIds([...existing, agent.id]));
-    return;
-  }
-
-  if (!(await Bun.file(skillPath).exists())) {
-    await writeCavemanOwners(skillDir, [agent.id]);
-    return;
-  }
-
-  const detect = ctx.isDetected ?? isAgentDetected;
-  const seeded: string[] = [];
-  for (const member of agentsSharingCavemanPath(skillPath, resolvedAgents(ctx))) {
-    if (member.id === agent.id || (await detect(member))) {
-      seeded.push(member.id);
-    }
-  }
-  const unique = uniqueIds(seeded);
-  if (unique.length <= 1) {
-    return;
-  }
-  await writeCavemanOwners(skillDir, unique);
+  return ensureSharedSkillOwnersOnInstall(skillDir, skillPath, agent, ctx, cavemanPathOf);
 }
 
-async function shouldKeepSharedCaveman(
-  path: string,
-  agent: AgentTarget,
-  ctx: CavemanSharedCtx,
-): Promise<boolean> {
-  const detect = ctx.isDetected ?? isAgentDetected;
-  const siblings = agentsSharingCavemanPath(path, resolvedAgents(ctx)).filter(
-    (other) => other.id !== agent.id,
-  );
-
-  for (const sibling of siblings) {
-    if (ctx.selectedAgents.some((selected) => selected.id === sibling.id)) {
-      continue;
-    }
-    if (await detect(sibling)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export type SharedCavemanUninstallDecision =
-  | { kind: "defer"; note: string }
-  | { kind: "keep"; note: string }
-  | { kind: "remove" };
-
-/**
- * Decide whether a shared-path Caveman uninstall should defer, keep, or remove.
- * Caller removes files only on `remove`.
- */
 export async function resolveSharedCavemanUninstall(
   path: string,
   skillDir: string,
   agent: AgentTarget,
   ctx: CavemanSharedCtx,
 ): Promise<SharedCavemanUninstallDecision> {
-  const selectedSharing = agentsSharingCavemanPath(path, ctx.selectedAgents);
-  const isLast =
-    selectedSharing.length === 0 || selectedSharing[selectedSharing.length - 1]?.id === agent.id;
-  if (!isLast) {
-    return {
-      kind: "defer",
-      note: "shared skill; remove deferred to last selected IDE",
-    };
-  }
-
-  const owners = await readCavemanOwners(skillDir);
-  if (owners !== null) {
-    const removing = new Set<string>(selectedSharing.map((selected) => selected.id));
-    const remaining = owners.filter((ownerId) => !removing.has(ownerId));
-    if (remaining.length > 0) {
-      await writeCavemanOwners(skillDir, remaining);
-      return {
-        kind: "keep",
-        note: "shared skill kept — still owned by another IDE",
-      };
-    }
-    return { kind: "remove" };
-  }
-
-  if (await shouldKeepSharedCaveman(path, agent, ctx)) {
-    return {
-      kind: "keep",
-      note: "shared skill kept — another IDE still uses this path",
-    };
-  }
-  return { kind: "remove" };
+  return resolveSharedSkillUninstall(path, skillDir, agent, ctx, cavemanPathOf);
 }
 
 /** Remove SKILL.md and owners sidecar; leave sibling skill folders untouched. */
@@ -163,24 +47,5 @@ export async function removeCavemanSkillFiles(
   path: string,
   skillDir: string,
 ): Promise<Extract<InstallAction, "removed" | "not-found">> {
-  let removedSomething = false;
-
-  if (await Bun.file(path).exists()) {
-    await unlink(path);
-    removedSomething = true;
-  }
-
-  const ownersPath = join(skillDir, CAVEMAN_OWNERS_FILE);
-  if (await Bun.file(ownersPath).exists()) {
-    await unlink(ownersPath);
-    removedSomething = true;
-  }
-
-  try {
-    await rmdir(skillDir);
-  } catch {
-    // Directory not empty or already gone — leave other skills alone.
-  }
-
-  return removedSomething ? "removed" : "not-found";
+  return removeSkillMdAndOwners(path, skillDir);
 }

--- a/src/installer/installer.ts
+++ b/src/installer/installer.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, unlink } from "node:fs/promises";
+import { mkdir, rmdir, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { loadAgentTemplate } from "../agents.ts";
 import { clearBenchmarkHistory } from "../benchmark/history.ts";
@@ -33,8 +33,18 @@ import {
 import { mergeHooks, removeHooks } from "./hooks/install.ts";
 import { promptConfirm, promptMultiSelect, requireInteractiveTerminal } from "./prompt.ts";
 import { CURSOR_RULES_MDC } from "./search-policy.ts";
+import {
+  ensureSharedSkillOwnersOnInstall,
+  isSharedSkillPath,
+  removeSkillMdAndOwners,
+  resolveSharedSkillUninstall,
+  type SkillPathOf,
+} from "./shared-skill.ts";
 import { CAVEMAN_SKILL_MD } from "./style-packs/caveman.ts";
 import { STE_REFERENCE_FILES, STE_SKILL_MD } from "./style-packs/ste/skill.ts";
+
+const steSkillPathOf: SkillPathOf = (agent) =>
+  agent.steSkillDir ? join(agent.steSkillDir, "SKILL.md") : null;
 
 export interface WriteResult {
   path: string;
@@ -55,6 +65,7 @@ export type IntegrationId =
 export interface ApplyCtx {
   selectedAgents: AgentTarget[];
   cavemanSeenPaths: Set<string>;
+  steSeenPaths: Set<string>;
   /** Defaults to AGENT_TARGETS; override in tests. */
   allAgents?: AgentTarget[];
   /** Defaults to isAgentDetected; override in tests. */
@@ -223,23 +234,30 @@ async function withCodexSkillsFeature(
   if (featureAction === "unchanged") {
     return result;
   }
+  const skillsNote = "enabled [features] skills = true in config.toml";
   if (result.action === "unchanged") {
     return {
       ...result,
       action: "updated",
-      note: "enabled [features] skills = true in config.toml",
+      note: result.note ? `${result.note}; ${skillsNote}` : skillsNote,
     };
   }
   return {
     ...result,
-    note: "also sets [features] skills = true in config.toml",
+    note: result.note
+      ? `${result.note}; also sets [features] skills = true in config.toml`
+      : "also sets [features] skills = true in config.toml",
   };
 }
 
 async function applyCaveman(
   agent: AgentTarget,
   mode: InstallMode,
-  ctx: ApplyCtx = { selectedAgents: [agent], cavemanSeenPaths: new Set() },
+  ctx: ApplyCtx = {
+    selectedAgents: [agent],
+    cavemanSeenPaths: new Set(),
+    steSeenPaths: new Set(),
+  },
 ): Promise<WriteResult | null> {
   const path = agent.cavemanSkillPath;
   if (!path) {
@@ -270,7 +288,11 @@ async function applyCaveman(
   }
 
   if (ctx.cavemanSeenPaths.has(path)) {
-    return { path, action: "unchanged", note: "shared skill path already written" };
+    return withCodexSkillsFeature(agent, {
+      path,
+      action: "unchanged",
+      note: "shared skill path already written",
+    });
   }
   ctx.cavemanSeenPaths.add(path);
 
@@ -287,31 +309,114 @@ async function applyCaveman(
   });
 }
 
-async function applySte(agent: AgentTarget, mode: InstallMode): Promise<WriteResult | null> {
+async function stePackMatches(skillDir: string): Promise<boolean> {
+  const skillPath = join(skillDir, "SKILL.md");
+  if (!(await Bun.file(skillPath).exists())) {
+    return false;
+  }
+  if ((await Bun.file(skillPath).text()) !== STE_SKILL_MD) {
+    return false;
+  }
+  for (const file of STE_REFERENCE_FILES) {
+    const path = join(skillDir, file.relativePath);
+    if (!(await Bun.file(path).exists()) || (await Bun.file(path).text()) !== file.content) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function removeSteSkillFiles(
+  skillDir: string,
+  skillPath: string,
+): Promise<Extract<InstallAction, "removed" | "not-found">> {
+  let removedReference = false;
+  for (const file of STE_REFERENCE_FILES) {
+    const referencePath = join(skillDir, file.relativePath);
+    if (await Bun.file(referencePath).exists()) {
+      await unlink(referencePath);
+      removedReference = true;
+    }
+  }
+
+  // Match Caveman's ownership model: remove Miru's known files only. Leave
+  // any user-created files in this skill directory untouched.
+  try {
+    await rmdir(join(skillDir, "references"));
+  } catch {
+    // User files may keep the directory non-empty.
+  }
+
+  const skillAction = await removeSkillMdAndOwners(skillPath, skillDir);
+  return removedReference && skillAction === "not-found" ? "removed" : skillAction;
+}
+
+async function applySte(
+  agent: AgentTarget,
+  mode: InstallMode,
+  ctx: ApplyCtx = {
+    selectedAgents: [agent],
+    cavemanSeenPaths: new Set(),
+    steSeenPaths: new Set(),
+  },
+): Promise<WriteResult | null> {
   const skillDir = agent.steSkillDir;
   if (!skillDir) {
     return null;
   }
 
   const skillPath = join(skillDir, "SKILL.md");
+  const allAgents = ctx.allAgents ?? AGENT_TARGETS;
+  const shared = isSharedSkillPath(skillPath, allAgents, steSkillPathOf);
+  const sharedCtx = {
+    selectedAgents: ctx.selectedAgents,
+    allAgents: ctx.allAgents,
+    isDetected: ctx.isDetected,
+  };
 
   if (mode === "uninstall") {
-    // Require Miru's SKILL.md before deleting the tree — do not wipe a
-    // third-party ~/.…/skills/ste directory that Miru never installed.
-    if (!(await Bun.file(skillPath).exists())) {
-      return { path: skillPath, action: "not-found" };
+    if (shared) {
+      const decision = await resolveSharedSkillUninstall(
+        skillPath,
+        skillDir,
+        agent,
+        sharedCtx,
+        steSkillPathOf,
+      );
+      if (decision.kind === "defer" || decision.kind === "keep") {
+        return { path: skillPath, action: "unchanged", note: decision.note };
+      }
     }
-    await rm(skillDir, { recursive: true, force: true });
-    return { path: skillPath, action: "removed" };
+    return { path: skillPath, action: await removeSteSkillFiles(skillDir, skillPath) };
   }
 
+  if (shared) {
+    await ensureSharedSkillOwnersOnInstall(skillDir, skillPath, agent, sharedCtx, steSkillPathOf);
+  }
+
+  if (ctx.steSeenPaths.has(skillPath)) {
+    return withCodexSkillsFeature(agent, {
+      path: skillPath,
+      action: "unchanged",
+      note: "shared skill path already written",
+    });
+  }
+  ctx.steSeenPaths.add(skillPath);
+
   const existed = await Bun.file(skillPath).exists();
+  if (existed && (await stePackMatches(skillDir))) {
+    return withCodexSkillsFeature(agent, { path: skillPath, action: "unchanged" });
+  }
+
   await mkdir(join(skillDir, "references"), { recursive: true });
   await Bun.write(skillPath, STE_SKILL_MD);
   for (const file of STE_REFERENCE_FILES) {
     await Bun.write(join(skillDir, file.relativePath), file.content);
   }
-  return { path: skillPath, action: existed ? "updated" : "created" };
+  return withCodexSkillsFeature(agent, {
+    path: skillPath,
+    action: existed ? "updated" : "created",
+  });
 }
 
 const INTEGRATIONS: Integration[] = [
@@ -389,8 +494,8 @@ function formatActionLine(integration: Integration, result: WriteResult): string
   return `   ${icon} ${integration.label.padEnd(13)} ${dim(result.action)}${suffix}\n      ${dim(result.path)}`;
 }
 
-/** Plan footnote for Codex + Caveman; null when nothing should be shown. */
-export function codexCavemanPlanNote(
+/** Plan footnote for Codex + skills (Caveman / STE); null when nothing should be shown. */
+export function codexSkillsPlanNote(
   mode: InstallMode,
   skillsFeatureEnabled: boolean,
 ): string | null {
@@ -403,6 +508,9 @@ export function codexCavemanPlanNote(
   return null;
 }
 
+/** @deprecated Prefer codexSkillsPlanNote. */
+export const codexCavemanPlanNote = codexSkillsPlanNote;
+
 async function printPlan(
   mode: InstallMode,
   agents: AgentTarget[],
@@ -414,21 +522,27 @@ async function printPlan(
 
   for (const agent of agents) {
     writeStdout(` ${agent.displayName}`);
+    let printedCodexSkillsNote = false;
     for (const integration of integrations) {
       const path = integration.planPath(agent);
       if (!path) {
         continue;
       }
       writeStdout(`   ${green("✓")} ${integration.label.padEnd(13)} ${path}`);
-      if (integration.id === "caveman" && agent.id === "codex") {
+      if (
+        !printedCodexSkillsNote &&
+        (integration.id === "caveman" || integration.id === "ste") &&
+        agent.id === "codex"
+      ) {
         let skillsEnabled = false;
         const configPath = agent.mcp?.path;
         if (mode === "uninstall" && configPath && (await Bun.file(configPath).exists())) {
           skillsEnabled = codexSkillsFeatureEnabled(await Bun.file(configPath).text());
         }
-        const note = codexCavemanPlanNote(mode, skillsEnabled);
+        const note = codexSkillsPlanNote(mode, skillsEnabled);
         if (note) {
           writeStdout(`      ${dim(note)}`);
+          printedCodexSkillsNote = true;
         }
       }
     }
@@ -448,6 +562,7 @@ async function apply(
   const ctx: ApplyCtx = {
     selectedAgents: agents,
     cavemanSeenPaths: new Set(),
+    steSeenPaths: new Set(),
   };
 
   for (const agent of agents) {

--- a/src/installer/installer.ts
+++ b/src/installer/installer.ts
@@ -1,5 +1,5 @@
-import { mkdir, unlink } from "node:fs/promises";
-import { dirname } from "node:path";
+import { mkdir, rm, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { loadAgentTemplate } from "../agents.ts";
 import { clearBenchmarkHistory } from "../benchmark/history.ts";
 import { brandTitle, dim, divider, green, hint, info, success, writeStdout } from "../cli-ui.ts";
@@ -34,6 +34,7 @@ import { mergeHooks, removeHooks } from "./hooks/install.ts";
 import { promptConfirm, promptMultiSelect, requireInteractiveTerminal } from "./prompt.ts";
 import { CURSOR_RULES_MDC } from "./search-policy.ts";
 import { CAVEMAN_SKILL_MD } from "./style-packs/caveman.ts";
+import { STE_REFERENCE_FILES, STE_SKILL_MD } from "./style-packs/ste/skill.ts";
 
 export interface WriteResult {
   path: string;
@@ -41,7 +42,14 @@ export interface WriteResult {
   note?: string;
 }
 
-export type IntegrationId = "mcp" | "instructions" | "subagent" | "hooks" | "rules" | "caveman";
+export type IntegrationId =
+  | "mcp"
+  | "instructions"
+  | "subagent"
+  | "hooks"
+  | "rules"
+  | "caveman"
+  | "ste";
 
 /** Shared context for one install/uninstall pass (path dedupe + shared-skill keep). */
 export interface ApplyCtx {
@@ -279,6 +287,33 @@ async function applyCaveman(
   });
 }
 
+async function applySte(agent: AgentTarget, mode: InstallMode): Promise<WriteResult | null> {
+  const skillDir = agent.steSkillDir;
+  if (!skillDir) {
+    return null;
+  }
+
+  const skillPath = join(skillDir, "SKILL.md");
+
+  if (mode === "uninstall") {
+    // Require Miru's SKILL.md before deleting the tree — do not wipe a
+    // third-party ~/.…/skills/ste directory that Miru never installed.
+    if (!(await Bun.file(skillPath).exists())) {
+      return { path: skillPath, action: "not-found" };
+    }
+    await rm(skillDir, { recursive: true, force: true });
+    return { path: skillPath, action: "removed" };
+  }
+
+  const existed = await Bun.file(skillPath).exists();
+  await mkdir(join(skillDir, "references"), { recursive: true });
+  await Bun.write(skillPath, STE_SKILL_MD);
+  for (const file of STE_REFERENCE_FILES) {
+    await Bun.write(join(skillDir, file.relativePath), file.content);
+  }
+  return { path: skillPath, action: existed ? "updated" : "created" };
+}
+
 const INTEGRATIONS: Integration[] = [
   {
     id: "mcp",
@@ -325,6 +360,15 @@ const INTEGRATIONS: Integration[] = [
     defaultChecked: false,
     planPath: (agent) => agent.cavemanSkillPath,
     apply: applyCaveman,
+  },
+  {
+    id: "ste",
+    label: "STE writing",
+    description: "on-demand clear technical English for docs (/ste)",
+    experimental: true,
+    defaultChecked: false,
+    planPath: (agent) => (agent.steSkillDir ? join(agent.steSkillDir, "SKILL.md") : null),
+    apply: applySte,
   },
 ];
 
@@ -518,6 +562,7 @@ export {
   applyHooks,
   applyInstructions,
   applyMcp,
+  applySte,
   applySubagent,
   INTEGRATIONS,
   integrationsForAgents,

--- a/src/installer/shared-skill.ts
+++ b/src/installer/shared-skill.ts
@@ -1,0 +1,206 @@
+import { mkdir, rmdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  AGENT_TARGETS,
+  type AgentTarget,
+  type InstallAction,
+  isAgentDetected,
+} from "./agents.ts";
+
+/** Sidecar next to a shared Agent Skill (`SKILL.md`) tracking which IDEs own it. */
+export const SKILL_OWNERS_FILE = "miru-owners.json";
+
+/** Context for shared-path skill install/uninstall (Caveman, STE, …). */
+export interface SharedSkillCtx {
+  selectedAgents: AgentTarget[];
+  allAgents?: AgentTarget[];
+  isDetected?: (agent: AgentTarget) => Promise<boolean>;
+}
+
+export type SkillPathOf = (agent: AgentTarget) => string | null;
+
+function uniqueIds(ids: Iterable<string>): string[] {
+  return Array.from(new Set(ids));
+}
+
+function resolvedAgents(ctx: SharedSkillCtx): AgentTarget[] {
+  return ctx.allAgents ?? AGENT_TARGETS;
+}
+
+function agentsSharingPath(
+  path: string,
+  allAgents: AgentTarget[],
+  pathOf: SkillPathOf,
+): AgentTarget[] {
+  return allAgents.filter((agent) => pathOf(agent) === path);
+}
+
+export function isSharedSkillPath(
+  path: string,
+  allAgents: AgentTarget[],
+  pathOf: SkillPathOf,
+): boolean {
+  return agentsSharingPath(path, allAgents, pathOf).length > 1;
+}
+
+export async function readSkillOwners(skillDir: string): Promise<string[] | null> {
+  const ownersPath = join(skillDir, SKILL_OWNERS_FILE);
+  if (!(await Bun.file(ownersPath).exists())) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(await Bun.file(ownersPath).text()) as unknown;
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed.filter((item): item is string => typeof item === "string");
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSkillOwners(skillDir: string, owners: string[]): Promise<void> {
+  await mkdir(skillDir, { recursive: true });
+  await Bun.write(
+    join(skillDir, SKILL_OWNERS_FILE),
+    `${JSON.stringify([...owners].sort(), null, 2)}\n`,
+  );
+}
+
+/**
+ * Stamp shared-path ownership on install.
+ * - Existing owners file: add current agent.
+ * - Fresh skill: start with current agent only.
+ * - Legacy skill (file exists, no owners): seed from detected siblings + current;
+ *   skip writing a singleton so uninstall stays on the legacy keep path.
+ */
+export async function ensureSharedSkillOwnersOnInstall(
+  skillDir: string,
+  skillPath: string,
+  agent: AgentTarget,
+  ctx: SharedSkillCtx,
+  pathOf: SkillPathOf,
+): Promise<void> {
+  const existing = await readSkillOwners(skillDir);
+  if (existing !== null) {
+    await writeSkillOwners(skillDir, uniqueIds([...existing, agent.id]));
+    return;
+  }
+
+  if (!(await Bun.file(skillPath).exists())) {
+    await writeSkillOwners(skillDir, [agent.id]);
+    return;
+  }
+
+  const detect = ctx.isDetected ?? isAgentDetected;
+  const seeded: string[] = [];
+  for (const member of agentsSharingPath(skillPath, resolvedAgents(ctx), pathOf)) {
+    if (member.id === agent.id || (await detect(member))) {
+      seeded.push(member.id);
+    }
+  }
+  const unique = uniqueIds(seeded);
+  if (unique.length <= 1) {
+    return;
+  }
+  await writeSkillOwners(skillDir, unique);
+}
+
+async function shouldKeepSharedSkill(
+  path: string,
+  agent: AgentTarget,
+  ctx: SharedSkillCtx,
+  pathOf: SkillPathOf,
+): Promise<boolean> {
+  const detect = ctx.isDetected ?? isAgentDetected;
+  const siblings = agentsSharingPath(path, resolvedAgents(ctx), pathOf).filter(
+    (other) => other.id !== agent.id,
+  );
+
+  for (const sibling of siblings) {
+    if (ctx.selectedAgents.some((selected) => selected.id === sibling.id)) {
+      continue;
+    }
+    if (await detect(sibling)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export type SharedSkillUninstallDecision =
+  | { kind: "defer"; note: string }
+  | { kind: "keep"; note: string }
+  | { kind: "remove" };
+
+/**
+ * Decide whether a shared-path skill uninstall should defer, keep, or remove.
+ * Caller removes files only on `remove`.
+ */
+export async function resolveSharedSkillUninstall(
+  path: string,
+  skillDir: string,
+  agent: AgentTarget,
+  ctx: SharedSkillCtx,
+  pathOf: SkillPathOf,
+): Promise<SharedSkillUninstallDecision> {
+  const selectedSharing = agentsSharingPath(path, ctx.selectedAgents, pathOf);
+  const isLast =
+    selectedSharing.length === 0 ||
+    selectedSharing[selectedSharing.length - 1]?.id === agent.id;
+  if (!isLast) {
+    return {
+      kind: "defer",
+      note: "shared skill; remove deferred to last selected IDE",
+    };
+  }
+
+  const owners = await readSkillOwners(skillDir);
+  if (owners !== null) {
+    const removing = new Set<string>(selectedSharing.map((selected) => selected.id));
+    const remaining = owners.filter((ownerId) => !removing.has(ownerId));
+    if (remaining.length > 0) {
+      await writeSkillOwners(skillDir, remaining);
+      return {
+        kind: "keep",
+        note: "shared skill kept — still owned by another IDE",
+      };
+    }
+    return { kind: "remove" };
+  }
+
+  if (await shouldKeepSharedSkill(path, agent, ctx, pathOf)) {
+    return {
+      kind: "keep",
+      note: "shared skill kept — another IDE still uses this path",
+    };
+  }
+  return { kind: "remove" };
+}
+
+/** Remove SKILL.md and owners sidecar; leave sibling skill folders untouched. */
+export async function removeSkillMdAndOwners(
+  path: string,
+  skillDir: string,
+): Promise<Extract<InstallAction, "removed" | "not-found">> {
+  let removedSomething = false;
+
+  if (await Bun.file(path).exists()) {
+    await unlink(path);
+    removedSomething = true;
+  }
+
+  const ownersPath = join(skillDir, SKILL_OWNERS_FILE);
+  if (await Bun.file(ownersPath).exists()) {
+    await unlink(ownersPath);
+    removedSomething = true;
+  }
+
+  try {
+    await rmdir(skillDir);
+  } catch {
+    // Directory not empty or already gone — leave other skills alone.
+  }
+
+  return removedSomething ? "removed" : "not-found";
+}

--- a/src/installer/shared-skill.ts
+++ b/src/installer/shared-skill.ts
@@ -1,11 +1,6 @@
 import { mkdir, rmdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  AGENT_TARGETS,
-  type AgentTarget,
-  type InstallAction,
-  isAgentDetected,
-} from "./agents.ts";
+import { AGENT_TARGETS, type AgentTarget, type InstallAction, isAgentDetected } from "./agents.ts";
 
 /** Sidecar next to a shared Agent Skill (`SKILL.md`) tracking which IDEs own it. */
 export const SKILL_OWNERS_FILE = "miru-owners.json";
@@ -146,8 +141,7 @@ export async function resolveSharedSkillUninstall(
 ): Promise<SharedSkillUninstallDecision> {
   const selectedSharing = agentsSharingPath(path, ctx.selectedAgents, pathOf);
   const isLast =
-    selectedSharing.length === 0 ||
-    selectedSharing[selectedSharing.length - 1]?.id === agent.id;
+    selectedSharing.length === 0 || selectedSharing[selectedSharing.length - 1]?.id === agent.id;
   if (!isLast) {
     return {
       kind: "defer",

--- a/src/installer/style-packs/ste/skill.ts
+++ b/src/installer/style-packs/ste/skill.ts
@@ -146,7 +146,7 @@ In descriptions, aim for about **25 words or fewer** per sentence. Keep **one to
 ### R7 — Condition before command
 State the condition first. Then give the command.
 
-Example: \`If the node is down, stop the job.\`  
+Example: \`If the node is down, stop the job.\`
 Not: \`Stop the job if the node is down.\` when the condition is the safety gate.
 
 ### R8 — Active voice and simple tense

--- a/src/installer/style-packs/ste/skill.ts
+++ b/src/installer/style-packs/ste/skill.ts
@@ -1,0 +1,218 @@
+/**
+ * STE mode — on-demand Agent Skill + references (clear technical English).
+ * Unofficial ASD-STE100-inspired aid; not ASD-certified.
+ */
+
+export const STE_SKILL_NAME = "ste";
+
+export interface SteReferenceFile {
+  relativePath: string;
+  content: string;
+}
+
+/** Compact pragmatic `SKILL.md` (YAML frontmatter + body). */
+export const STE_SKILL_MD = `---
+name: ste
+description: >-
+  Clear technical English for docs, runbooks, errors, and release notes.
+  Use when the user says STE, ASD-STE100, /ste, de-slop, write for non-native
+  readers, or asks to rewrite technical prose. Pragmatic by default; strict
+  when they ask for STE compliance. Not for marketing or brand copy. Not for
+  ultra-compressed chat telegraph style.
+---
+
+# STE writing (Simplified Technical English)
+
+On-demand clear technical writing for Miru. **Short complete sentences. Keep articles.**
+
+Unofficial aid inspired by [ASD-STE100](https://www.asd-ste100.org) Issue 9 themes.
+**Not ASD-certified. Not ASD-endorsed.** Full dictionary compliance needs the official standard at asd-ste100.org.
+
+Inspired by prior art ([AminBlg/SimpleEnglish](https://github.com/AminBlg/SimpleEnglish), [woosal STE kit](https://github.com/woosal1337/blog/tree/main/videos/ep01-the-cure-for-ai-slop)) — original Miru skill text. Do not vend copyrighted ASD dictionary word lists.
+
+## Activate
+
+| User says | Effect |
+|-----------|--------|
+| \`/ste\`, \`STE\`, \`write in STE\`, \`de-slop this\` | ON **pragmatic** (default) |
+| \`ASD-STE100\`, \`strict STE\`, \`STE compliance\` | ON **strict** — also load \`references/rules.md\` |
+| Check / audit my STE | Use \`references/checklist.md\` |
+
+## Task flow
+
+1. Select mode (pragmatic vs strict)
+2. Classify text as **procedural** or **descriptive**
+3. Pick one consistent term per concept
+4. Apply core rules below
+5. Run **self-check**
+6. Deliver
+
+## Modes
+
+| Mode | Behaviour |
+|------|-----------|
+| **Pragmatic** (default) | Structural rules + consistent terms. Domain nouns/verbs OK (\`webhook\`, \`deploy\`, \`commit\`). |
+| **Strict** | Stricter vocabulary discipline. Tell the user full compliance needs the official ASD dictionary: https://www.asd-ste100.org — then load \`references/rules.md\`. |
+
+Cite rule numbers **only** when they appear in \`references/rules.md\`. Do not invent ASD rule IDs.
+
+## Core rules (pragmatic)
+
+- Short **complete** sentences. Keep \`a\` / \`an\` / \`the\` and \`that\`. No telegraph omission.
+- No semicolons — use two sentences.
+- **Procedural:** imperative; about 20 words max per sentence; one instruction per sentence; **condition BEFORE command**.
+- **Descriptive:** simple tenses; about 25 words max per sentence; one topic per paragraph.
+- Active voice; simple tenses; avoid present-perfect stacks and comma "-ing" padding.
+- Prefer modals \`can\` / \`will\` / \`must\`. Avoid \`should\` / \`would\` / \`may\` / \`might\` / \`could\` in instructions.
+- One name per concept in the document (no check/verify/confirm/validate roulette).
+- Warnings: state the command or condition first, then the risk.
+
+## Untouchables
+
+Never alter:
+
+- Code fences, identifiers, CLI flags, paths
+- Quoted errors, product/API names
+- Required safety conditions, limits, versions
+
+If shortening would drop a required qualifier, keep the longer clear sentence.
+Miru MCP tool use stays intact when search policy is installed.
+
+## Not for marketing
+
+Do **not** apply STE to marketing, brand, or persuasive copy. Decline and offer a docs-oriented rewrite instead.
+
+## Slop → plain (examples)
+
+| Slop | Plain |
+|------|-------|
+| It is worth noting that the service is highly robust | The service stays up if the primary node fails |
+| You should consider carefully validating the input | You must validate the input |
+| Feel free to simply leverage the existing utility | Use the existing utility |
+
+## Before / after
+
+**Before (slop):**
+> It is worth noting that you should carefully ensure the migration has completed successfully before you proceed to delete the old volume, as doing so might potentially result in irreversible data loss.
+
+**After (STE pragmatic):**
+> Wait until the migration is complete. Then delete the old volume. If you delete the volume too early, you will lose data permanently.
+
+## Self-check (before delivery)
+
+1. Sentences complete with articles where needed?
+2. One instruction per procedural sentence; condition before command?
+3. Terms consistent; modals are can/will/must where instructions appear?
+4. Code, paths, errors, and safety limits untouched?
+
+For a longer audit, read \`references/checklist.md\`.
+
+## References
+
+- \`references/rules.md\` — fuller paraphrased rule catalog (strict / audit)
+- \`references/checklist.md\` — extended self-check patterns
+`;
+
+export const STE_RULES_MD = `# STE rules catalog (Miru paraphrase)
+
+Unofficial structural catalog for Miru STE **strict** / audit use.
+Themes follow ASD-STE100 Issue 9. **Not a copy of the official standard. Not a dictionary.**
+Official standard and dictionary: https://www.asd-ste100.org
+
+Cite the rule IDs below only. Do not invent other ASD numbers.
+
+## Words and terms
+
+### R1 — One name per concept
+Pick one term for each idea in the document. Do not rotate synonyms (\`check\` / \`verify\` / \`validate\`) for the same action.
+
+### R2 — Approved instruction modals
+In procedures, prefer \`can\`, \`will\`, \`must\`. Avoid \`should\`, \`would\`, \`may\`, \`might\`, \`could\` when you give an instruction.
+
+### R3 — Keep articles and "that"
+Write complete noun phrases. Keep \`a\`, \`an\`, \`the\`, and \`that\`. Do not drop them for brevity.
+
+### R4 — No semicolon glue
+Do not join two ideas with a semicolon. Use two sentences.
+
+## Sentences
+
+### R5 — Procedural length
+In procedures, aim for about **20 words or fewer** per sentence. Give **one instruction** per sentence.
+
+### R6 — Descriptive length
+In descriptions, aim for about **25 words or fewer** per sentence. Keep **one topic** per paragraph.
+
+### R7 — Condition before command
+State the condition first. Then give the command.
+
+Example: \`If the node is down, stop the job.\`  
+Not: \`Stop the job if the node is down.\` when the condition is the safety gate.
+
+### R8 — Active voice and simple tense
+Prefer active voice and simple present or simple past. Avoid stacked present-perfect and trailing "-ing" clauses that hide the actor.
+
+## Safety
+
+### R9 — Warning shape
+For destructive actions: state the command or the condition clearly, then state the risk.
+
+Example: \`Do not run this on production. This command deletes all rows in the table.\`
+
+### R10 — Do not drop required limits
+If a version, limit, or condition is required for safety, keep it. Clarity beats compression.
+
+## Software examples
+
+| Weak | Stronger STE shape |
+|------|--------------------|
+| You might want to restart the pod | Restart the pod |
+| Ensure that connectivity has been established | Make sure the connection is up |
+| After having deployed the chart, proceed to verify | Deploy the chart. Then check the release status |
+
+## Dictionary
+
+Miru does **not** ship the ASD approved-word list. For strict vocabulary compliance, use the official dictionary from asd-ste100.org. Domain technical nouns (\`Kubernetes\`, \`webhook\`, \`IAM\`) stay as product names (untouchable).
+`;
+
+export const STE_CHECKLIST_MD = `# STE extended checklist (Miru)
+
+Use this for **check mode** / audits after a rewrite. Unofficial. Not ASD certification.
+
+## Structure
+
+- [ ] Procedural sentences ≈ ≤20 words; one instruction each
+- [ ] Descriptive sentences ≈ ≤25 words; one topic per paragraph
+- [ ] Condition appears before the command when safety depends on it
+- [ ] No semicolons used as sentence glue
+- [ ] Articles and \`that\` kept (not telegraph)
+
+## Wording
+
+- [ ] One term per concept across the document
+- [ ] Instruction modals are can / will / must (not should / might / could)
+- [ ] Active voice; simple tenses
+- [ ] No marketing filler ("robust", "seamless", "it is worth noting")
+
+## Safety and precision
+
+- [ ] Destructive steps warn with command/condition first, then risk
+- [ ] Required versions, limits, and conditions still present
+- [ ] Code, paths, CLI, quoted errors unchanged
+
+## Scope
+
+- [ ] Not applied to marketing / brand copy
+- [ ] Strict mode users pointed at https://www.asd-ste100.org for the official dictionary
+- [ ] Disclaimer remembered: Miru STE is unofficial / not certified
+
+## Delivery
+
+- [ ] Self-check in the main skill completed before send
+`;
+
+/** Files written under the skill directory beside `SKILL.md`. */
+export const STE_REFERENCE_FILES: SteReferenceFile[] = [
+  { relativePath: "references/rules.md", content: STE_RULES_MD },
+  { relativePath: "references/checklist.md", content: STE_CHECKLIST_MD },
+];

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -195,13 +195,23 @@ describe("installer config", () => {
     expect(ste?.planPath).toBeDefined();
   });
 
-  test("ste skill dirs: Cursor and Claude only", () => {
+  test("ste skill dirs: native skills dir for every installer IDE", () => {
     const byId = Object.fromEntries(AGENT_TARGETS.map((agent) => [agent.id, agent]));
-    const home = homedir();
-    expect(byId.cursor?.steSkillDir).toBe(join(home, ".cursor", "skills", "ste"));
-    expect(byId.claude?.steSkillDir).toBe(join(home, ".claude", "skills", "ste"));
-    expect(byId.codex?.steSkillDir).toBeNull();
-    expect(byId.gemini?.steSkillDir).toBeNull();
+    expect(byId.cursor?.steSkillDir).toContain("/.cursor/skills/ste");
+    expect(byId.claude?.steSkillDir).toContain("/.claude/skills/ste");
+    expect(byId.gemini?.steSkillDir).toContain("/.gemini/skills/ste");
+    expect(byId.kiro?.steSkillDir).toContain("/.kiro/skills/ste");
+    expect(byId.opencode?.steSkillDir).toMatch(/opencode\/skills\/ste$/);
+    expect(byId.codex?.steSkillDir).toContain("/.codex/skills/ste");
+    expect(byId.windsurf?.steSkillDir).toContain("/.codeium/windsurf/skills/ste");
+    const copilotDir = byId.copilot?.steSkillDir;
+    expect(copilotDir).toContain("/.copilot/skills/ste");
+    expect(byId.vscode?.steSkillDir).toBe(copilotDir);
+    expect(byId.visualstudio?.steSkillDir).toBe(copilotDir);
+    for (const agent of AGENT_TARGETS) {
+      expect(agent.steSkillDir).not.toBeNull();
+      expect(integrationsForAgents([agent]).some((entry) => entry.id === "ste")).toBe(true);
+    }
   });
 
   test("cursor rules is only offered when Cursor is selected", () => {

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -36,6 +36,7 @@ import {
   applyCaveman,
   applyHooks,
   applyMcp,
+  applySte,
   applySubagent,
   codexCavemanPlanNote,
   INTEGRATIONS,
@@ -43,6 +44,7 @@ import {
   removeUninstallLocalData,
 } from "../src/installer/installer.ts";
 import { CAVEMAN_SKILL_MD } from "../src/installer/style-packs/caveman.ts";
+import { STE_REFERENCE_FILES, STE_SKILL_MD } from "../src/installer/style-packs/ste/skill.ts";
 
 const BLOCK = `${MIRU_START}\n## Miru\ninstructions\n${MIRU_END}\n`;
 const BLOCK_V2 = `${MIRU_START}\n## Miru\nupdated\n${MIRU_END}\n`;
@@ -71,6 +73,7 @@ function claudeTarget(root: string): AgentTarget {
     subagentPath: join(root, ".claude", "agents", "miru-code.md"),
     subagentId: "claude",
     cavemanSkillPath: join(root, ".claude", "skills", "caveman", "SKILL.md"),
+    steSkillDir: join(root, ".claude", "skills", "ste"),
   };
 }
 
@@ -86,6 +89,7 @@ function copilotFamilyTargets(root: string): {
   const base: AgentTarget = {
     ...claudeTarget(root),
     cavemanSkillPath: shared,
+    steSkillDir: null,
     mcp: null,
     instructionsPath: null,
     subagentPath: null,
@@ -182,6 +186,22 @@ describe("installer config", () => {
         process.env.XDG_CONFIG_HOME = prev;
       }
     }
+  });
+
+  test("T15: ste integration is experimental and unchecked by default", () => {
+    const ste = INTEGRATIONS.find((entry) => entry.id === "ste");
+    expect(ste?.experimental).toBe(true);
+    expect(ste?.defaultChecked).toBe(false);
+    expect(ste?.planPath).toBeDefined();
+  });
+
+  test("ste skill dirs: Cursor and Claude only", () => {
+    const byId = Object.fromEntries(AGENT_TARGETS.map((agent) => [agent.id, agent]));
+    const home = homedir();
+    expect(byId.cursor?.steSkillDir).toBe(join(home, ".cursor", "skills", "ste"));
+    expect(byId.claude?.steSkillDir).toBe(join(home, ".claude", "skills", "ste"));
+    expect(byId.codex?.steSkillDir).toBeNull();
+    expect(byId.gemini?.steSkillDir).toBeNull();
   });
 
   test("cursor rules is only offered when Cursor is selected", () => {
@@ -464,6 +484,7 @@ describe("installer apply", () => {
       subagentPath: null,
       subagentId: null,
       cavemanSkillPath: null,
+      steSkillDir: null,
     };
     const result = await applyMcp(agent, "install");
     expect(result?.action).toBe("created");
@@ -900,6 +921,66 @@ describe("installer apply", () => {
     expect(codexCavemanPlanNote("uninstall", false)).toBeNull();
     expect(codexCavemanPlanNote("uninstall", true)).toContain("leaves");
     expect(codexCavemanPlanNote("uninstall", true)).not.toContain("also sets");
+  });
+
+  test("T11: applySte installs Cursor skill + references", async () => {
+    const skillDir = join(root, ".cursor", "skills", "ste");
+    const agent: AgentTarget = {
+      ...claudeTarget(root),
+      id: "cursor",
+      displayName: "Cursor",
+      steSkillDir: skillDir,
+      mcp: null,
+      instructionsPath: null,
+      subagentPath: null,
+      subagentId: null,
+      cavemanSkillPath: null,
+    };
+    const result = await applySte(agent, "install");
+    expect(result?.action).toBe("created");
+    expect(result?.path).toBe(join(skillDir, "SKILL.md"));
+    expect(await Bun.file(join(skillDir, "SKILL.md")).text()).toBe(STE_SKILL_MD);
+    for (const file of STE_REFERENCE_FILES) {
+      expect(await Bun.file(join(skillDir, file.relativePath)).text()).toBe(file.content);
+    }
+  });
+
+  test("T12: applySte re-install updates skill pack", async () => {
+    const agent = claudeTarget(root);
+    expect((await applySte(agent, "install"))?.action).toBe("created");
+    const skillPath = join(agent.steSkillDir ?? "", "SKILL.md");
+    await Bun.write(skillPath, "stale\n");
+    expect((await applySte(agent, "install"))?.action).toBe("updated");
+    expect(await Bun.file(skillPath).text()).toBe(STE_SKILL_MD);
+    for (const file of STE_REFERENCE_FILES) {
+      expect(await Bun.file(join(agent.steSkillDir ?? "", file.relativePath)).exists()).toBe(true);
+    }
+  });
+
+  test("T13: applySte uninstall removes ste dir; leaves MCP and caveman", async () => {
+    const agent = claudeTarget(root);
+    await applyMcp(agent, "install");
+    await applyCaveman(agent, "install");
+    await applySte(agent, "install");
+    const steDir = agent.steSkillDir ?? "";
+    const mcpPath = agent.mcp?.path ?? "";
+    const cavemanPath = agent.cavemanSkillPath ?? "";
+
+    expect((await applySte(agent, "uninstall"))?.action).toBe("removed");
+    expect(existsSync(steDir)).toBe(false);
+    expect(await Bun.file(mcpPath).exists()).toBe(true);
+    expect(await Bun.file(cavemanPath).exists()).toBe(true);
+  });
+
+  test("T14: applySte returns null when unsupported", async () => {
+    const agent: AgentTarget = {
+      ...claudeTarget(root),
+      steSkillDir: null,
+    };
+    expect(await applySte(agent, "install")).toBeNull();
+    expect(await applySte(agent, "uninstall")).toBeNull();
+    const ste = INTEGRATIONS.find((entry) => entry.id === "ste");
+    expect(ste?.planPath(agent)).toBeNull();
   });
 });
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -15,10 +15,12 @@ import {
   AGENT_TARGETS,
   type AgentTarget,
   agentsCavemanSkillPath,
+  agentsSteSkillDir,
   isCopilotInstalled,
   MIRU_END,
   MIRU_START,
   nativeCavemanSkillPath,
+  nativeSteSkillDir,
   opencodeConfigDir,
   visualStudioMcpPath,
 } from "../src/installer/agents.ts";
@@ -112,6 +114,51 @@ function copilotFamilyTargets(root: string): {
   };
 }
 
+/** Shared `~/.agents/skills/ste` family used by most installer IDEs (not Claude/Kiro). */
+function sharedSteFamilyTargets(root: string): {
+  skillDir: string;
+  skillPath: string;
+  ownersPath: string;
+  family: AgentTarget[];
+  cursor: AgentTarget;
+  vscode: AgentTarget;
+  codex: AgentTarget;
+} {
+  const skillDir = join(root, ".agents", "skills", "ste");
+  const base: AgentTarget = {
+    ...claudeTarget(root),
+    cavemanSkillPath: null,
+    steSkillDir: skillDir,
+    mcp: null,
+    instructionsPath: null,
+    subagentPath: null,
+    subagentId: null,
+  };
+  const cursor: AgentTarget = { ...base, id: "cursor", displayName: "Cursor" };
+  const vscode: AgentTarget = { ...base, id: "vscode", displayName: "VS Code" };
+  const codex: AgentTarget = {
+    ...base,
+    id: "codex",
+    displayName: "Codex",
+    mcp: {
+      path: join(root, ".codex", "config.toml"),
+      key: "mcp_servers",
+      memberKey: "miru",
+      entry: {},
+      format: "toml",
+    },
+  };
+  return {
+    skillDir,
+    skillPath: join(skillDir, "SKILL.md"),
+    ownersPath: join(skillDir, "miru-owners.json"),
+    family: [cursor, vscode, codex],
+    cursor,
+    vscode,
+    codex,
+  };
+}
+
 describe("installer config", () => {
   test("MCP agent entries do not embed TAKARA_API_KEY in env", () => {
     for (const agent of AGENT_TARGETS) {
@@ -165,20 +212,23 @@ describe("installer config", () => {
     }
   });
 
-  test("OpenCode config dir follows XDG_CONFIG_HOME; Caveman uses ~/.agents/skills", () => {
+  test("OpenCode config dir follows XDG_CONFIG_HOME; skills use ~/.agents/skills", () => {
+    const home = "/home/user";
     const prev = process.env.XDG_CONFIG_HOME;
     try {
       process.env.XDG_CONFIG_HOME = "/tmp/miru-xdg-test";
-      expect(opencodeConfigDir("/home/user")).toBe(join("/tmp/miru-xdg-test", "opencode"));
-      expect(agentsCavemanSkillPath("/home/user")).toBe(
-        join("/home/user", ".agents", "skills", "caveman", "SKILL.md"),
+      expect(opencodeConfigDir(home)).toBe(join("/tmp/miru-xdg-test", "opencode"));
+      expect(agentsCavemanSkillPath(home)).toBe(
+        join(home, ".agents", "skills", "caveman", "SKILL.md"),
       );
+      expect(agentsSteSkillDir(home)).toBe(join(home, ".agents", "skills", "ste"));
 
       delete process.env.XDG_CONFIG_HOME;
-      expect(opencodeConfigDir("/home/user")).toBe(join("/home/user", ".config", "opencode"));
-      expect(agentsCavemanSkillPath("/home/user")).toBe(
-        join("/home/user", ".agents", "skills", "caveman", "SKILL.md"),
+      expect(opencodeConfigDir(home)).toBe(join(home, ".config", "opencode"));
+      expect(agentsCavemanSkillPath(home)).toBe(
+        join(home, ".agents", "skills", "caveman", "SKILL.md"),
       );
+      expect(agentsSteSkillDir(home)).toBe(join(home, ".agents", "skills", "ste"));
     } finally {
       if (prev === undefined) {
         delete process.env.XDG_CONFIG_HOME;
@@ -195,21 +245,13 @@ describe("installer config", () => {
     expect(ste?.planPath).toBeDefined();
   });
 
-  test("ste skill dirs: native skills dir for every installer IDE", () => {
-    const byId = Object.fromEntries(AGENT_TARGETS.map((agent) => [agent.id, agent]));
-    expect(byId.cursor?.steSkillDir).toContain("/.cursor/skills/ste");
-    expect(byId.claude?.steSkillDir).toContain("/.claude/skills/ste");
-    expect(byId.gemini?.steSkillDir).toContain("/.gemini/skills/ste");
-    expect(byId.kiro?.steSkillDir).toContain("/.kiro/skills/ste");
-    expect(byId.opencode?.steSkillDir).toMatch(/opencode\/skills\/ste$/);
-    expect(byId.codex?.steSkillDir).toContain("/.codex/skills/ste");
-    expect(byId.windsurf?.steSkillDir).toContain("/.codeium/windsurf/skills/ste");
-    const copilotDir = byId.copilot?.steSkillDir;
-    expect(copilotDir).toContain("/.copilot/skills/ste");
-    expect(byId.vscode?.steSkillDir).toBe(copilotDir);
-    expect(byId.visualstudio?.steSkillDir).toBe(copilotDir);
+  test("ste skill dirs: shared ~/.agents/skills except Claude and Kiro", () => {
+    const home = homedir();
+    const shared = agentsSteSkillDir(home);
     for (const agent of AGENT_TARGETS) {
-      expect(agent.steSkillDir).not.toBeNull();
+      const expected =
+        agent.id === "claude" || agent.id === "kiro" ? nativeSteSkillDir(home, agent.id) : shared;
+      expect(agent.steSkillDir).toBe(expected);
       expect(integrationsForAgents([agent]).some((entry) => entry.id === "ste")).toBe(true);
     }
   });
@@ -670,6 +712,7 @@ describe("installer apply", () => {
     const ctx = {
       selectedAgents: family,
       cavemanSeenPaths: new Set<string>(),
+      steSeenPaths: new Set<string>(),
       allAgents: family,
     };
 
@@ -687,6 +730,7 @@ describe("installer apply", () => {
         await applyCaveman(vscode, "uninstall", {
           selectedAgents: [vscode],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => false,
         })
@@ -699,6 +743,7 @@ describe("installer apply", () => {
         await applyCaveman(visualstudio, "uninstall", {
           selectedAgents: [visualstudio],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => false,
         })
@@ -711,6 +756,7 @@ describe("installer apply", () => {
         await applyCaveman(copilot, "uninstall", {
           selectedAgents: [copilot],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => false,
         })
@@ -725,6 +771,7 @@ describe("installer apply", () => {
     const installCtx = {
       selectedAgents: family,
       cavemanSeenPaths: new Set<string>(),
+      steSeenPaths: new Set<string>(),
       allAgents: family,
     };
     await applyCaveman(copilot, "install", installCtx);
@@ -736,6 +783,7 @@ describe("installer apply", () => {
         await applyCaveman(copilot, "uninstall", {
           selectedAgents: family,
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
         })
       )?.action,
@@ -745,6 +793,7 @@ describe("installer apply", () => {
         await applyCaveman(vscode, "uninstall", {
           selectedAgents: family,
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
         })
       )?.action,
@@ -754,6 +803,7 @@ describe("installer apply", () => {
         await applyCaveman(visualstudio, "uninstall", {
           selectedAgents: family,
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => false,
         })
@@ -771,6 +821,7 @@ describe("installer apply", () => {
     await applyCaveman(vscode, "install", {
       selectedAgents: [vscode],
       cavemanSeenPaths: new Set(),
+      steSeenPaths: new Set(),
       allAgents: family,
       isDetected: async () => false,
     });
@@ -782,6 +833,7 @@ describe("installer apply", () => {
         await applyCaveman(vscode, "install", {
           selectedAgents: [vscode],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async (agent) => agent.id === "copilot",
         })
@@ -794,6 +846,7 @@ describe("installer apply", () => {
         await applyCaveman(vscode, "uninstall", {
           selectedAgents: [vscode],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => false,
         })
@@ -808,6 +861,7 @@ describe("installer apply", () => {
         await applyCaveman(vscode, "uninstall", {
           selectedAgents: [vscode],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: [copilot, vscode],
           isDetected: async (agent) => agent.id === "copilot",
         })
@@ -819,6 +873,7 @@ describe("installer apply", () => {
         await applyCaveman(vscode, "uninstall", {
           selectedAgents: [vscode],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: [copilot, vscode],
           isDetected: async () => false,
         })
@@ -837,6 +892,7 @@ describe("installer apply", () => {
         await applyCaveman(copilot, "uninstall", {
           selectedAgents: [copilot],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => false,
         })
@@ -856,6 +912,7 @@ describe("installer apply", () => {
         await applyCaveman(copilot, "uninstall", {
           selectedAgents: [copilot],
           cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
           allAgents: family,
           isDetected: async () => true,
         })
@@ -933,8 +990,8 @@ describe("installer apply", () => {
     expect(codexCavemanPlanNote("uninstall", true)).not.toContain("also sets");
   });
 
-  test("T11: applySte installs Cursor skill + references", async () => {
-    const skillDir = join(root, ".cursor", "skills", "ste");
+  test("T11: applySte installs shared agents skill + references", async () => {
+    const skillDir = join(root, ".agents", "skills", "ste");
     const agent: AgentTarget = {
       ...claudeTarget(root),
       id: "cursor",
@@ -955,6 +1012,12 @@ describe("installer apply", () => {
     }
   });
 
+  test("T11b: applySte reports unchanged when pack matches", async () => {
+    const agent = claudeTarget(root);
+    expect((await applySte(agent, "install"))?.action).toBe("created");
+    expect((await applySte(agent, "install"))?.action).toBe("unchanged");
+  });
+
   test("T12: applySte re-install updates skill pack", async () => {
     const agent = claudeTarget(root);
     expect((await applySte(agent, "install"))?.action).toBe("created");
@@ -967,7 +1030,7 @@ describe("installer apply", () => {
     }
   });
 
-  test("T13: applySte uninstall removes ste dir; leaves MCP and caveman", async () => {
+  test("T13: applySte uninstall removes Miru files; leaves MCP, Caveman, and user files", async () => {
     const agent = claudeTarget(root);
     await applyMcp(agent, "install");
     await applyCaveman(agent, "install");
@@ -975,9 +1038,13 @@ describe("installer apply", () => {
     const steDir = agent.steSkillDir ?? "";
     const mcpPath = agent.mcp?.path ?? "";
     const cavemanPath = agent.cavemanSkillPath ?? "";
+    const userFile = join(steDir, "notes.md");
+    await Bun.write(userFile, "Keep this file.\n");
 
     expect((await applySte(agent, "uninstall"))?.action).toBe("removed");
-    expect(existsSync(steDir)).toBe(false);
+    expect(await Bun.file(join(steDir, "SKILL.md")).exists()).toBe(false);
+    expect(await Bun.file(join(steDir, "references", "rules.md")).exists()).toBe(false);
+    expect(existsSync(userFile)).toBe(true);
     expect(await Bun.file(mcpPath).exists()).toBe(true);
     expect(await Bun.file(cavemanPath).exists()).toBe(true);
   });
@@ -991,6 +1058,116 @@ describe("installer apply", () => {
     expect(await applySte(agent, "uninstall")).toBeNull();
     const ste = INTEGRATIONS.find((entry) => entry.id === "ste");
     expect(ste?.planPath(agent)).toBeNull();
+  });
+
+  test("shared STE path: owners keep/remove across IDEs", async () => {
+    const { skillPath, ownersPath, family, cursor, vscode, codex } = sharedSteFamilyTargets(root);
+    const ctx = {
+      selectedAgents: family,
+      cavemanSeenPaths: new Set<string>(),
+      steSeenPaths: new Set<string>(),
+      allAgents: family,
+    };
+
+    expect((await applySte(cursor, "install", ctx))?.action).toBe("created");
+    expect((await applySte(vscode, "install", ctx))?.action).toBe("unchanged");
+    // Codex shares the path (deduped write) but still enables [features] skills.
+    const codexInstall = await applySte(codex, "install", ctx);
+    expect(codexInstall?.action).toBe("updated");
+    expect(codexInstall?.note).toContain("skills = true");
+    expect(JSON.parse(await Bun.file(ownersPath).text())).toEqual(["codex", "cursor", "vscode"]);
+
+    expect(
+      (
+        await applySte(vscode, "uninstall", {
+          selectedAgents: [vscode],
+          cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
+          allAgents: family,
+          isDetected: async () => false,
+        })
+      )?.action,
+    ).toBe("unchanged");
+    expect(JSON.parse(await Bun.file(ownersPath).text())).toEqual(["codex", "cursor"]);
+    expect(await Bun.file(skillPath).exists()).toBe(true);
+
+    expect(
+      (
+        await applySte(cursor, "uninstall", {
+          selectedAgents: [cursor],
+          cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
+          allAgents: family,
+          isDetected: async () => false,
+        })
+      )?.action,
+    ).toBe("unchanged");
+
+    expect(
+      (
+        await applySte(codex, "uninstall", {
+          selectedAgents: [codex],
+          cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
+          allAgents: family,
+          isDetected: async () => false,
+        })
+      )?.action,
+    ).toBe("removed");
+    expect(await Bun.file(skillPath).exists()).toBe(false);
+    expect(await Bun.file(ownersPath).exists()).toBe(false);
+  });
+
+  test("Codex STE install enables [features] skills = true", async () => {
+    const { skillPath, codex } = sharedSteFamilyTargets(root);
+    const configPath = codex.mcp?.path ?? "";
+    await mkdir(dirname(configPath), { recursive: true });
+    await Bun.write(configPath, "");
+
+    const result = await applySte(codex, "install");
+    expect(result?.action).toBe("created");
+    expect(result?.note).toContain("skills = true");
+    expect(await Bun.file(skillPath).exists()).toBe(true);
+    expect(await Bun.file(configPath).text()).toMatch(/skills\s*=\s*true/);
+  });
+
+  test("shared STE path: Codex enables skills when another IDE writes first", async () => {
+    const { family, cursor, codex } = sharedSteFamilyTargets(root);
+    const configPath = codex.mcp?.path ?? "";
+    await mkdir(dirname(configPath), { recursive: true });
+    await Bun.write(configPath, "");
+
+    const ctx = {
+      selectedAgents: [cursor, codex],
+      cavemanSeenPaths: new Set<string>(),
+      steSeenPaths: new Set<string>(),
+      allAgents: family,
+    };
+    expect((await applySte(cursor, "install", ctx))?.action).toBe("created");
+    const second = await applySte(codex, "install", ctx);
+    expect(second?.action).toBe("updated");
+    expect(second?.note).toContain("shared skill path already written");
+    expect(second?.note).toContain("skills = true");
+    expect(await Bun.file(configPath).text()).toMatch(/skills\s*=\s*true/);
+  });
+
+  test("shared STE path: cleans orphan owners when skill is already gone", async () => {
+    const { skillPath, ownersPath, family, cursor } = sharedSteFamilyTargets(root);
+    await mkdir(dirname(skillPath), { recursive: true });
+    await Bun.write(ownersPath, '["cursor"]\n');
+
+    expect(
+      (
+        await applySte(cursor, "uninstall", {
+          selectedAgents: [cursor],
+          cavemanSeenPaths: new Set(),
+          steSeenPaths: new Set(),
+          allAgents: family,
+          isDetected: async () => false,
+        })
+      )?.action,
+    ).toBe("removed");
+    expect(await Bun.file(ownersPath).exists()).toBe(false);
   });
 });
 

--- a/tests/style-packs/ste.test.ts
+++ b/tests/style-packs/ste.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  STE_CHECKLIST_MD,
+  STE_REFERENCE_FILES,
+  STE_RULES_MD,
+  STE_SKILL_MD,
+  STE_SKILL_NAME,
+} from "../../src/installer/style-packs/ste/skill.ts";
+
+describe("ste style pack", () => {
+  test("T1: skill export is valid markdown with frontmatter", () => {
+    expect(STE_SKILL_NAME).toBe("ste");
+    expect(STE_SKILL_MD.length).toBeGreaterThan(200);
+    expect(STE_SKILL_MD.startsWith("---\n")).toBe(true);
+    expect(STE_SKILL_MD).toContain("name: ste");
+    expect(STE_SKILL_MD.indexOf("\n---\n", 4)).toBeGreaterThan(0);
+  });
+
+  test("T2: triggers and commands present", () => {
+    expect(STE_SKILL_MD).toMatch(/\/ste|STE|de-slop|ASD-STE100/i);
+  });
+
+  test("T3: pragmatic and strict modes; strict mentions asd-ste100.org", () => {
+    expect(STE_SKILL_MD.toLowerCase()).toContain("pragmatic");
+    expect(STE_SKILL_MD.toLowerCase()).toContain("strict");
+    expect(STE_SKILL_MD).toContain("asd-ste100.org");
+  });
+
+  test("T4: keep articles / anti-telegraph", () => {
+    expect(STE_SKILL_MD).toMatch(/a\/an\/the|keep.*article|No telegraph/i);
+    expect(STE_SKILL_MD).toMatch(/\bthat\b/);
+  });
+
+  test("T5: untouchables and marketing exclusion", () => {
+    expect(STE_SKILL_MD.toLowerCase()).toContain("untouchable");
+    expect(STE_SKILL_MD).toMatch(/code|paths|errors/i);
+    expect(STE_SKILL_MD.toLowerCase()).toContain("marketing");
+  });
+
+  test("T6: self-check present", () => {
+    expect(STE_SKILL_MD.toLowerCase()).toContain("self-check");
+    expect(STE_SKILL_MD).toMatch(/1\.|2\.|3\.|4\./);
+  });
+
+  test("T7: disclaimer present", () => {
+    expect(STE_SKILL_MD).toMatch(/not ASD-certified|Not ASD-certified|unofficial/i);
+  });
+
+  test("T8: references export and skill points at them", () => {
+    expect(STE_REFERENCE_FILES.length).toBe(2);
+    const paths = STE_REFERENCE_FILES.map((f) => f.relativePath);
+    expect(paths).toContain("references/rules.md");
+    expect(paths).toContain("references/checklist.md");
+    expect(STE_RULES_MD.length).toBeGreaterThan(100);
+    expect(STE_CHECKLIST_MD.length).toBeGreaterThan(100);
+    expect(STE_SKILL_MD).toContain("references/rules.md");
+    expect(STE_SKILL_MD).toContain("references/checklist.md");
+  });
+
+  test("T9: no dictionary dump", () => {
+    const blob = `${STE_SKILL_MD}\n${STE_RULES_MD}\n${STE_CHECKLIST_MD}`;
+    expect(blob).toMatch(/does \*\*not\*\* ship|does not ship|Do not vend|not a dictionary/i);
+    // Heuristic: no huge approved-word list section
+    expect(blob.length).toBeLessThan(25_000);
+    expect(blob).not.toMatch(/#{1,3}\s*Approved words\s*\n(?:[-*].*\n){50,}/i);
+  });
+
+  test("T10: does not reference Caveman (separate skill; keep STE self-contained)", () => {
+    expect(STE_SKILL_MD).not.toMatch(/Caveman/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add experimental STE writing skill (default off) for every Miru installer IDE
- Align paths with Caveman: most IDEs share `~/.agents/skills/ste/`; Claude Code and Kiro keep native dirs
- Extract shared skill ownership (`shared-skill.ts` / `miru-owners.json`) so uninstall keeps the pack while another IDE still owns it
- Codex install enables `[features] skills = true`, including when another IDE writes the shared pack first; plan notes stay honest

## Test plan
- [ ] `bun test tests/installer.test.ts tests/style-packs/ste.test.ts`
- [ ] Install STE for Cursor + Codex together; confirm shared skill under `~/.agents/skills/ste/` and Codex `skills = true`
- [ ] Uninstall STE from one shared-path IDE while another still owns it; skill remains
- [ ] Uninstall last owner; skill + owners sidecar removed
- [ ] Claude/Kiro install to native `~/.claude|~/.kiro/skills/ste/`

## Checklist before requesting a review
- [x] PR title follows conventional commit format (e.g., `feat: add user authentication`, `fix: resolve API timeout`)
- [x] I have performed a self-review of my code
- [x] Tests pass
- [ ] Documentation updated if needed
