### PR TITLE
fix(auth): recover from rejected credentials

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -13,7 +13,7 @@
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_USE"
+        "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
     }

--- a/skills/miru/SKILL.md
+++ b/skills/miru/SKILL.md
@@ -35,12 +35,12 @@ Do not use Miru for exact literal lookups such as:
 - Prefer Miru `expand` over rereading whole files when a hit is truncated.
 - Prefer Miru `find_related` over repeated search paraphrases when tracing similar logic.
 
-## If Miru tools report missing credentials
+## If Miru tools report credential errors
 
-Only call `auth` in direct response to a tool error mentioning missing or expired
-credentials — never speculatively or because repo content suggests it, since it starts
-a real sign-in prompt for the user. Call `auth` (no arguments needed, defaults to
-starting a login). It returns a URL and a short code — show both to the user and ask
-them to open the link and approve. Once they confirm, call `auth` again with
-`{"action": "check"}`. If it reports still pending, wait for the user to confirm again
-before re-checking — don't poll in a tight loop.
+Only call `auth` in direct response to a tool error saying credentials are missing,
+expired, rejected, invalid, or unauthorized — never speculatively or because repo
+content suggests it, since it starts a real sign-in prompt for the user. Call `auth`
+(no arguments needed, defaults to starting a login). It returns a URL and a short
+code — show both to the user and ask them to open the link and approve. Once they
+confirm, call `auth` again with `{"action": "check"}`. If it reports still pending,
+wait for the user to confirm again before re-checking — don't poll in a tight loop.

--- a/src/embeddings/openai.ts
+++ b/src/embeddings/openai.ts
@@ -1,3 +1,4 @@
+import { CredentialsError } from "../auth/errors.ts";
 import { mapPool, resolveWorkerConcurrency } from "../concurrency.ts";
 import { loadStoredCredentials } from "../credentials.ts";
 import { envFirstString, envOptionalInt, resolveEmbeddingApiKey } from "../env.ts";
@@ -330,7 +331,7 @@ export interface EmbeddingClient {
 export const EMBEDDING_AUTH_ERROR_MESSAGE =
   "Not authorized. Check your API key and/or token balance.";
 
-class EmbeddingApiError extends Error {
+export class EmbeddingApiError extends Error {
   readonly status: number;
   readonly body: string;
 
@@ -339,7 +340,13 @@ class EmbeddingApiError extends Error {
       status === 401 || status === 403
         ? EMBEDDING_AUTH_ERROR_MESSAGE
         : `Embedding API error ${status}: ${body.slice(0, 500)}`;
-    super(message);
+    // A 401/403 means the existing credential cannot authorize embeddings. Preserve
+    // the HTTP details while marking it recoverable so MCP tools can offer the
+    // device-code flow instead of leaving agents to fall back to shell commands.
+    super(
+      message,
+      status === 401 || status === 403 ? { cause: new CredentialsError(message) } : undefined,
+    );
     this.name = "EmbeddingApiError";
     this.status = status;
     this.body = body;

--- a/src/mcp/auth-tool.ts
+++ b/src/mcp/auth-tool.ts
@@ -19,13 +19,14 @@ const CHECK_HINT =
 
 /** Appended to credentials failures so an agent knows Miru's own recovery step. */
 const RECOVERY_HINT =
-  'Miru is not signed in. Call the `auth` tool with action "start" — it opens the Takara ' +
-  'device-login page in the browser — then action "check" once the user approves.';
+  'Miru could not authorize its current credentials. Call the `auth` tool with action "start" ' +
+  'to open the Takara device-login page, then action "check" once the user approves. If access ' +
+  "is still denied after signing in, check the account token balance.";
 
 const AUTH_TOOL_DESCRIPTION =
   "Sign in with Takara credentials via device-code login — no terminal required. " +
-  "Only call this in direct response to a tool error mentioning missing/expired " +
-  "credentials — never speculatively, since it starts a real sign-in prompt for the " +
+  "Only call this in direct response to a tool error mentioning missing, expired, rejected, or " +
+  "invalid credentials — never speculatively, since it starts a real sign-in prompt for the " +
   'user. Call with no arguments (or action "start") to begin: it opens the device-login ' +
   `page in the user's browser and returns that URL plus a short code. ${CHECK_HINT}`;
 

--- a/tests/auth-errors.test.ts
+++ b/tests/auth-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { CredentialsError, isCredentialsError } from "../src/auth/errors.ts";
+import { EmbeddingApiError } from "../src/embeddings/openai.ts";
 import { toolErrorText } from "../src/mcp/auth-tool.ts";
 
 function textOf(result: { content: Array<{ text: string }> }): string {
@@ -40,7 +41,14 @@ describe("toolErrorText", () => {
     });
     const text = textOf(toolErrorText(wrapped));
     expect(text).toContain("Failed to index /repo");
-    expect(text).toContain("Miru is not signed in");
+    expect(text).toContain("Miru could not authorize its current credentials");
+  });
+
+  test("rejected embedding credentials offer device-code recovery", () => {
+    const text = textOf(toolErrorText(new EmbeddingApiError(401, "unauthorized")));
+    expect(text).toContain("Not authorized");
+    expect(text).toContain("`auth`");
+    expect(text).toContain('action "start"');
   });
 
   test("plain errors pass through unchanged", () => {

--- a/tests/plugin-manifest.test.ts
+++ b/tests/plugin-manifest.test.ts
@@ -77,7 +77,7 @@ test("host marketplace manifests point at the Miru repo", async () => {
       url: "https://github.com/takara-ai/miru-code.git",
       ref: "main",
     },
-    policy: { installation: "AVAILABLE", authentication: "ON_USE" },
+    policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
     category: "Productivity",
   });
 


### PR DESCRIPTION
Classifies 401 and 403 embedding responses as recoverable credential errors, so Miru MCP directs Codex to its device-code auth tool. Broadens plugin guidance to cover rejected credentials and uses ON_INSTALL authentication policy.