### PR TITLE
Add CloudFormation/CDK examples for self-hosted SageMaker Marketplace endpoint

### DIFF
--- a/examples/sagemaker-marketplace/cdk/.gitignore
+++ b/examples/sagemaker-marketplace/cdk/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+cdk.out/
+*.js
+!jest.config.js
+*.d.ts

--- a/examples/sagemaker-marketplace/cdk/bin/app.ts
+++ b/examples/sagemaker-marketplace/cdk/bin/app.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { App } from "aws-cdk-lib";
+import { SageMakerMarketplaceEndpointStack } from "../lib/sagemaker-marketplace-endpoint-stack";
+
+const app = new App();
+
+// Required explicitly: without `env`, CDK deploys to whatever region the current AWS
+// profile/config defaults to (often not the region your ModelPackageArn is scoped to),
+// silently ignoring CDK_DEFAULT_REGION unless it's wired through here.
+const account = process.env.CDK_DEFAULT_ACCOUNT;
+const region = process.env.CDK_DEFAULT_REGION;
+if (!account || !region) {
+  throw new Error(
+    "CDK_DEFAULT_ACCOUNT and CDK_DEFAULT_REGION must be set (cdk deploy sets these " +
+      "automatically from your AWS credentials/profile, but double check --region/--profile " +
+      "match the region your ModelPackageArn was issued for).",
+  );
+}
+
+new SageMakerMarketplaceEndpointStack(app, "SageMakerMarketplaceEndpointStack", {
+  description: "SageMaker real-time endpoint for the DS1 AWS Marketplace model package",
+  env: { account, region },
+});

--- a/examples/sagemaker-marketplace/cdk/cdk.json
+++ b/examples/sagemaker-marketplace/cdk/cdk.json
@@ -1,0 +1,10 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": ["README.md", "cdk*.json", "**/*.d.ts", "**/*.js", "node_modules"]
+  },
+  "context": {
+    "@aws-cdk/core:newStyleStackSynthesis": true
+  }
+}

--- a/examples/sagemaker-marketplace/cdk/lib/sagemaker-marketplace-endpoint-stack.ts
+++ b/examples/sagemaker-marketplace/cdk/lib/sagemaker-marketplace-endpoint-stack.ts
@@ -1,0 +1,133 @@
+import { Aws, CfnOutput, CfnParameter, Stack, type StackProps } from "aws-cdk-lib";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnEndpoint, CfnEndpointConfig, CfnModel } from "aws-cdk-lib/aws-sagemaker";
+import type { Construct } from "constructs";
+
+/**
+ * Deploys a SageMaker real-time endpoint from the DS1 AWS Marketplace model package,
+ * for use with Miru. Mirrors ../cloudformation/sagemaker-marketplace-endpoint.yml —
+ * same parameters, resources, and outputs, built with CDK's L1 (Cfn*) constructs
+ * rather than opinionated L2 constructs, so the two stay in lockstep.
+ */
+export class SageMakerMarketplaceEndpointStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const modelPackageArn = new CfnParameter(this, "ModelPackageArn", {
+      type: "String",
+      description:
+        "ARN of the subscribed DS1 AWS Marketplace model package for this region " +
+        "(copy from the AWS Marketplace listing page after subscribing)",
+    });
+
+    const endpointName = new CfnParameter(this, "EndpointName", {
+      type: "String",
+      default: "ds1-endpoint",
+      description: "Name for the SageMaker endpoint",
+    });
+
+    const instanceType = new CfnParameter(this, "InstanceType", {
+      type: "String",
+      default: "ml.c5.xlarge",
+      description: "SageMaker instance type for the endpoint",
+    });
+
+    const initialInstanceCount = new CfnParameter(this, "InitialInstanceCount", {
+      type: "Number",
+      default: 1,
+      minValue: 1,
+      description: "Number of instances for the production variant",
+    });
+
+    const region = new CfnParameter(this, "Region", {
+      type: "String",
+      description:
+        "AWS region you are deploying into. Must match the --region/env you deploy " +
+        "with and the region of your ModelPackageArn — this parameter does not change " +
+        "where the stack deploys, it documents and lets you cross-check the intended region.",
+    });
+
+    const executionRole = new CfnRole(this, "SageMakerExecutionRole", {
+      roleName: `sagemaker-marketplace-exec-${endpointName.valueAsString}`,
+      assumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "sagemaker.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      policies: [
+        {
+          policyName: "sagemaker-marketplace-logs",
+          policyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Sid: "Logs",
+                Effect: "Allow",
+                Action: [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:PutLogEvents",
+                  "logs:DescribeLogStreams",
+                ],
+                Resource: `arn:aws:logs:${Aws.REGION}:${Aws.ACCOUNT_ID}:log-group:/aws/sagemaker/Endpoints/${endpointName.valueAsString}*`,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const model = new CfnModel(this, "Model", {
+      modelName: `${endpointName.valueAsString}-model`,
+      executionRoleArn: executionRole.attrArn,
+      enableNetworkIsolation: true,
+      primaryContainer: {
+        modelPackageName: modelPackageArn.valueAsString,
+      },
+    });
+    model.addResourceDependency(executionRole);
+
+    const endpointConfig = new CfnEndpointConfig(this, "EndpointConfig", {
+      endpointConfigName: `${endpointName.valueAsString}-config`,
+      productionVariants: [
+        {
+          variantName: "AllTraffic",
+          modelName: model.attrModelName,
+          initialInstanceCount: initialInstanceCount.valueAsNumber,
+          instanceType: instanceType.valueAsString,
+          containerStartupHealthCheckTimeoutInSeconds: 900,
+        },
+      ],
+    });
+    endpointConfig.addResourceDependency(model);
+
+    const endpoint = new CfnEndpoint(this, "Endpoint", {
+      endpointName: endpointName.valueAsString,
+      endpointConfigName: endpointConfig.attrEndpointConfigName,
+      tags: [{ key: "ExpectedRegion", value: region.valueAsString }],
+    });
+    endpoint.addResourceDependency(endpointConfig);
+
+    new CfnOutput(this, "ExecutionRoleArn", {
+      description: "IAM role ARN used by the SageMaker endpoint (needed for Miru configuration)",
+      value: executionRole.attrArn,
+    });
+    new CfnOutput(this, "EndpointArn", {
+      description: "SageMaker endpoint ARN (needed for Miru configuration)",
+      value: endpoint.attrEndpointArn,
+    });
+    new CfnOutput(this, "EndpointNameOut", {
+      description: "Endpoint name",
+      value: endpointName.valueAsString,
+    });
+    new CfnOutput(this, "RegionOut", {
+      description: "AWS region the stack was deployed into",
+      value: Aws.REGION,
+    });
+  }
+}

--- a/examples/sagemaker-marketplace/cdk/package-lock.json
+++ b/examples/sagemaker-marketplace/cdk/package-lock.json
@@ -1,0 +1,521 @@
+{
+  "name": "sagemaker-marketplace-endpoint-cdk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sagemaker-marketplace-endpoint-cdk",
+      "version": "1.0.0",
+      "dependencies": {
+        "aws-cdk-lib": "^2.170.0",
+        "constructs": "^10.4.2"
+      },
+      "bin": {
+        "sagemaker-marketplace-endpoint": "bin/app.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "aws-cdk": "^2.170.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.20.0.tgz",
+      "integrity": "sha512-ts2dVBi0VUXOLKcqyLYsHUWYpwGPFd+xm4q+6Y4jjP8orwodjRi2mJrmpy9b0gHnbv8e/hFnmEbqrD0bBJOnPA==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1138.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1138.0.tgz",
+      "integrity": "sha512-gZ5F8rmh+qc7ZNWsbaXYoV+p7jSYynRRg70s7FAn3VmzRaSkTE31ijpQHYroxCbDEtKSzgN63ORR/WuZmvXAwA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.266.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.266.0.tgz",
+      "integrity": "sha512-sBQU42pEc9ud3yeVU2En2euQRUhCg63eaJIPEVpBtE5aPhJjN3d9MkzQ9eYGLVXP3fnohUE54BiVOdUrkEDUbg==",
+      "bundleDependencies": [
+        "@aws/cloudformation-validate",
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.7.0-beta",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.6",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.5",
+        "punycode": "^2.3.1",
+        "semver": "^7.8.5",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.7.0-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
+      "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/examples/sagemaker-marketplace/cdk/package.json
+++ b/examples/sagemaker-marketplace/cdk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sagemaker-marketplace-endpoint-cdk",
+  "version": "1.0.0",
+  "private": true,
+  "description": "CDK app to deploy a SageMaker real-time endpoint from the DS1 AWS Marketplace model package, for use with Miru.",
+  "bin": {
+    "sagemaker-marketplace-endpoint": "bin/app.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "aws-cdk": "^2.170.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.2"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.170.0",
+    "constructs": "^10.4.2"
+  }
+}

--- a/examples/sagemaker-marketplace/cdk/tsconfig.json
+++ b/examples/sagemaker-marketplace/cdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "rootDir": "."
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/examples/sagemaker-marketplace/cloudformation/sagemaker-marketplace-endpoint.yml
+++ b/examples/sagemaker-marketplace/cloudformation/sagemaker-marketplace-endpoint.yml
@@ -1,0 +1,104 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy a SageMaker real-time endpoint from the DS1 AWS Marketplace model package, for use with Miru
+
+Parameters:
+  ModelPackageArn:
+    Type: String
+    Description: >-
+      ARN of the subscribed DS1 AWS Marketplace model package for this region
+      (copy from the AWS Marketplace listing page after subscribing)
+  EndpointName:
+    Type: String
+    Default: ds1-endpoint
+    Description: Name for the SageMaker endpoint
+  InstanceType:
+    Type: String
+    Default: ml.c5.xlarge
+    Description: SageMaker instance type for the endpoint
+  InitialInstanceCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    Description: Number of instances for the production variant
+  Region:
+    Type: String
+    Description: >-
+      AWS region you are deploying into. Must match the --region you pass to
+      the deploy command and the region of your ModelPackageArn — this
+      parameter does not change where the stack deploys, it documents and
+      lets you cross-check the intended region.
+
+Resources:
+  SageMakerExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub sagemaker-marketplace-exec-${EndpointName}
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sagemaker.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: sagemaker-marketplace-logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: Logs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogStreams
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/sagemaker/Endpoints/${EndpointName}*
+
+  Model:
+    Type: AWS::SageMaker::Model
+    DependsOn:
+      - SageMakerExecutionRole
+    Properties:
+      ModelName: !Sub ${EndpointName}-model
+      ExecutionRoleArn: !GetAtt SageMakerExecutionRole.Arn
+      EnableNetworkIsolation: true
+      PrimaryContainer:
+        ModelPackageName: !Ref ModelPackageArn
+
+  EndpointConfig:
+    Type: AWS::SageMaker::EndpointConfig
+    DependsOn:
+      - Model
+    Properties:
+      EndpointConfigName: !Sub ${EndpointName}-config
+      ProductionVariants:
+        - VariantName: AllTraffic
+          ModelName: !GetAtt Model.ModelName
+          InitialInstanceCount: !Ref InitialInstanceCount
+          InstanceType: !Ref InstanceType
+          ContainerStartupHealthCheckTimeoutInSeconds: 900
+
+  Endpoint:
+    Type: AWS::SageMaker::Endpoint
+    DependsOn:
+      - EndpointConfig
+    Properties:
+      EndpointName: !Ref EndpointName
+      EndpointConfigName: !GetAtt EndpointConfig.EndpointConfigName
+      Tags:
+        - Key: ExpectedRegion
+          Value: !Ref Region
+
+Outputs:
+  ExecutionRoleArn:
+    Description: IAM role ARN used by the SageMaker endpoint (needed for Miru configuration)
+    Value: !GetAtt SageMakerExecutionRole.Arn
+  EndpointArn:
+    Description: SageMaker endpoint ARN (needed for Miru configuration)
+    Value: !GetAtt Endpoint.EndpointArn
+  EndpointNameOut:
+    Description: Endpoint name
+    Value: !Ref EndpointName
+  RegionOut:
+    Description: AWS region the stack was deployed into
+    Value: !Ref AWS::Region

--- a/src/embeddings/sagemaker.ts
+++ b/src/embeddings/sagemaker.ts
@@ -108,11 +108,32 @@ export const SAGEMAKER_AUTH_ERROR_MESSAGE =
   "(AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_SESSION_TOKEN or AWS_PROFILE) and that the " +
   "identity has sagemaker:InvokeEndpoint permission on the endpoint.";
 
+/** Shown when the endpoint name in the stored/env config no longer exists. */
+export const SAGEMAKER_NOT_FOUND_ERROR_MESSAGE =
+  "SageMaker endpoint not found — it may have been deleted, renamed, or deployed in a " +
+  "different region. Confirm the endpoint still exists, then run `miru setup --sagemaker` " +
+  "again to re-authenticate and re-point Miru at the correct endpoint.";
+
+/** Shown for DNS/connection-level failures reaching the SageMaker Runtime API itself. */
+export const SAGEMAKER_UNREACHABLE_ERROR_MESSAGE =
+  "Could not reach the SageMaker endpoint (network error). Check your network/VPN/VPC " +
+  "access and that the configured region is correct, then run `miru setup --sagemaker` " +
+  "again to re-authenticate and re-validate the connection.";
+
 const AUTH_EXCEPTION_NAMES = new Set([
   "AccessDeniedException",
   "UnrecognizedClientException",
   "ExpiredTokenException",
   "CredentialsProviderError",
+]);
+
+/** Node/undici connection-level error codes — the request never reached AWS. */
+const NETWORK_ERROR_CODES = new Set([
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
 ]);
 
 class SageMakerInvokeError extends Error {
@@ -125,10 +146,11 @@ class SageMakerInvokeError extends Error {
   }
 }
 
-function toInvokeError(err: unknown): SageMakerInvokeError {
+export function toInvokeError(err: unknown): SageMakerInvokeError {
   const awsErr = err as {
     name?: string;
     message?: string;
+    code?: string;
     $metadata?: { httpStatusCode?: number };
     OriginalStatusCode?: string | number;
     OriginalMessage?: string;
@@ -136,6 +158,17 @@ function toInvokeError(err: unknown): SageMakerInvokeError {
 
   if (awsErr?.name && AUTH_EXCEPTION_NAMES.has(awsErr.name)) {
     return new SageMakerInvokeError(403, SAGEMAKER_AUTH_ERROR_MESSAGE);
+  }
+
+  // SageMaker returns a generic ValidationError for both "endpoint doesn't exist" and
+  // malformed-request cases — only the message distinguishes them.
+  if (awsErr?.name === "ValidationError" && /not found/i.test(awsErr?.message ?? "")) {
+    return new SageMakerInvokeError(404, SAGEMAKER_NOT_FOUND_ERROR_MESSAGE);
+  }
+
+  const errorCode = awsErr?.code ?? (err as { cause?: { code?: string } })?.cause?.code;
+  if (errorCode && NETWORK_ERROR_CODES.has(errorCode)) {
+    return new SageMakerInvokeError(503, SAGEMAKER_UNREACHABLE_ERROR_MESSAGE);
   }
 
   // ModelError wraps the embedding container's real status/message (e.g. 424 when the

--- a/tests/sagemaker-invoke-error.test.ts
+++ b/tests/sagemaker-invoke-error.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SAGEMAKER_AUTH_ERROR_MESSAGE,
+  SAGEMAKER_NOT_FOUND_ERROR_MESSAGE,
+  SAGEMAKER_UNREACHABLE_ERROR_MESSAGE,
+  toInvokeError,
+} from "../src/embeddings/sagemaker.ts";
+
+describe("toInvokeError", () => {
+  test("auth exceptions map to the auth error message", () => {
+    const err = toInvokeError({ name: "AccessDeniedException", message: "denied" });
+    expect(err.status).toBe(403);
+    expect(err.message).toBe(SAGEMAKER_AUTH_ERROR_MESSAGE);
+  });
+
+  test("ValidationError with 'not found' maps to the not-found message", () => {
+    const err = toInvokeError({
+      name: "ValidationError",
+      message: "Endpoint my-endpoint of account 123456789012 not found.",
+    });
+    expect(err.status).toBe(404);
+    expect(err.message).toBe(SAGEMAKER_NOT_FOUND_ERROR_MESSAGE);
+  });
+
+  test("ValidationError without 'not found' falls through to the generic message", () => {
+    const err = toInvokeError({
+      name: "ValidationError",
+      message: "1 validation error detected: bad request shape",
+      $metadata: { httpStatusCode: 400 },
+    });
+    expect(err.status).toBe(400);
+    expect(err.message).toContain("bad request shape");
+    expect(err.message).not.toBe(SAGEMAKER_NOT_FOUND_ERROR_MESSAGE);
+  });
+
+  test("DNS/connection error codes map to the unreachable message", () => {
+    const err = toInvokeError({ code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND" });
+    expect(err.status).toBe(503);
+    expect(err.message).toBe(SAGEMAKER_UNREACHABLE_ERROR_MESSAGE);
+  });
+
+  test("connection error codes nested under cause also map to the unreachable message", () => {
+    const err = toInvokeError({
+      message: "fetch failed",
+      cause: { code: "ECONNREFUSED" },
+    });
+    expect(err.status).toBe(503);
+    expect(err.message).toBe(SAGEMAKER_UNREACHABLE_ERROR_MESSAGE);
+  });
+});


### PR DESCRIPTION
## Summary

* Adds a CloudFormation template and an equivalent CDK app (`examples/sagemaker-marketplace/`) that deploy the DS1 AWS Marketplace model as a SageMaker real-time endpoint in a customer's own AWS account, including the execution IAM role — nothing manual required.
* Both expose `ModelPackageArn`, `EndpointName`, `InstanceType`, `InitialInstanceCount`, `Region` as parameters, and output `ExecutionRoleArn` + `EndpointArn` for Miru's self-hosted config.
* IAM execution role is scoped to the endpoint's own CloudWatch log group, not `Resource: '*'`.
* Improves `src/embeddings/sagemaker.ts` error messages: endpoint-not-found and network-unreachable failures now point at `miru setup --sagemaker` instead of surfacing a raw AWS exception.

## Validation

* `cfn-lint` clean on the CloudFormation template.
* `cdk synth` clean; CDK output shape verified to match the CloudFormation template's Parameters/Resources/Outputs.
* Both templates deployed live to a subscribed sandbox account, reached `EndpointStatus: InService`, and were successfully invoked end-to-end via Miru's own `sagemaker:auth-check` script. Torn down after verification.
* New unit tests for the error-message changes (`tests/sagemaker-invoke-error.test.ts`), `bun test`/`tsc --noEmit`/`biome check` all pass.

## Test plan

- [ ] `cd examples/sagemaker-marketplace/cdk && npm install && npx cdk synth`
- [ ] `uvx cfn-lint examples/sagemaker-marketplace/cloudformation/sagemaker-marketplace-endpoint.yml`
- [ ] `bun test tests/sagemaker-invoke-error.test.ts`

[PRD-434](https://linear.app/takara-ai/issue/PRD-434/create-cloudformationcdk-templates-to-deploy-a-marketplace-sagemaker) (docs update to make this the primary self-hosted setup path is tracked separately in [PRD-435](https://linear.app/takara-ai/issue/PRD-435/update-miru-sagemaker-setup-docs-to-use-the-deployment-templates)).