### PR TITLE
docs: make CloudFormation/CDK templates the primary SageMaker setup path

### DIFF
--- a/docs/self-hosted-sagemaker.md
+++ b/docs/self-hosted-sagemaker.md
@@ -1,6 +1,6 @@
 # Self-hosted embeddings (AWS SageMaker)
 
-Run Miru against your own SageMaker embedding endpoint instead of Takara’s hosted API (`infer.takara.ai`).
+Run Miru against your own SageMaker embedding endpoint instead of Takara's hosted API (`infer.takara.ai`).
 
 The embedding model is sold on AWS Marketplace:
 
@@ -8,15 +8,14 @@ The embedding model is sold on AWS Marketplace:
 
 ## Overview
 
+| Step | Who       | What                                                                          |
+| ---- | --------- | ------------------------------------------------------------------------------ |
+| 1    | AWS admin | Subscribe on Marketplace                                                       |
+| 2    | AWS admin | Deploy the endpoint with the CloudFormation/CDK template (below)               |
+| 3    | AWS admin | Create an invoke-only IAM user / profile (runbook below)                       |
+| 4    | Developer | `miru setup --sagemaker` — Miru validates and saves the endpoint               |
 
-| Step | Who       | What                                                             |
-| ---- | --------- | ---------------------------------------------------------------- |
-| 1    | AWS admin | Subscribe on Marketplace and deploy a SageMaker endpoint         |
-| 2    | AWS admin | Create an invoke-only IAM user / profile (runbook below)         |
-| 3    | Developer | `miru setup --sagemaker` — Miru validates and saves the endpoint |
-
-
-Miru **never** creates IAM users or writes `~/.aws`. It only inherits a profile you already have and checks that it can call the endpoint.
+Miru **never** creates IAM users, IAM roles, SageMaker resources, or writes `~/.aws`. It only inherits a profile you already have and checks that it can call the endpoint.
 
 ## One mode at a time
 
@@ -27,23 +26,108 @@ Miru stores **either** a Takara API key **or** a SageMaker endpoint — never bo
 
 You do not need `--clear` when switching; the other mode is purged automatically.
 
-## 1. Deploy the Marketplace endpoint
+## 1. Subscribe on AWS Marketplace
 
 1. Open the [Marketplace listing](https://aws.amazon.com/marketplace/pp/prodview-la5olwsicr6ue)
-2. Subscribe and deploy the model package as a SageMaker endpoint in your account
-3. Copy the endpoint ARN — it looks like:
+2. Subscribe to the DS1 model package for your region
+3. Copy the **model package ARN** for your region from the listing page — it looks like:
 
 ```text
-arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>
+arn:aws:sagemaker:<region>:<account-id>:model-package/<name>
 ```
 
+You'll pass this in as `ModelPackageArn` in step 2.
 
+## 2. Deploy the endpoint (CloudFormation or CDK)
 
-## 2. Create an invoke-only AWS profile (admin runbook)
+The supported way to deploy the endpoint is the template in
+[`examples/sagemaker-marketplace`](../examples/sagemaker-marketplace), from a clean AWS account with no
+prior SageMaker/Marketplace setup beyond the subscription above. Pick CloudFormation or CDK — both
+templates create the same resources and outputs.
 
-You need an AWS identity that can call `sagemaker:InvokeEndpoint` on that ARN. The simplest path for a laptop / CI user is a **least-privilege IAM user** scoped to that one endpoint, installed as a named profile.
+### Parameters
 
-From a checkout of this repo, with the [AWS CLI](https://docs.aws.amazon.com/cli/) available and **admin** credentials in your current shell:
+| Parameter              | Required | Default          | Description                                                                                                                         |
+| ----------------------- | -------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `ModelPackageArn`       | Yes      | —                 | ARN of the subscribed DS1 Marketplace model package from step 1                                                                       |
+| `EndpointName`          | No       | `ds1-endpoint`    | Name for the SageMaker endpoint                                                                                                       |
+| `InstanceType`          | No       | `ml.c5.xlarge`    | SageMaker instance type for the endpoint                                                                                              |
+| `InitialInstanceCount`  | No       | `1`               | Number of instances for the production variant                                                                                       |
+| `Region`                | Yes      | —                 | Region you're deploying into. Doesn't change where the stack deploys — it's a cross-check that must match `ModelPackageArn`'s region and your `--region`/profile |
+
+### What it creates
+
+- **`SageMakerExecutionRole`** (IAM role) — assumed by the SageMaker service to run the endpoint; scoped
+  to writing its own CloudWatch log group only
+- **`Model`** — SageMaker model pointing at the Marketplace model package, with network isolation enabled
+- **`EndpointConfig`** — production variant using `InstanceType` / `InitialInstanceCount`
+- **`Endpoint`** — the running SageMaker real-time endpoint
+
+### Outputs
+
+| Output              | Use                                                                 |
+| -------------------- | -------------------------------------------------------------------- |
+| `EndpointArn`         | Pass to `miru setup --sagemaker --arn …` in step 4                  |
+| `ExecutionRoleArn`    | The endpoint's IAM role (informational; not used by `miru setup`)  |
+| `EndpointNameOut`     | Endpoint name                                                       |
+| `RegionOut`           | Region the stack deployed into — should match `Region`              |
+
+### Deploy with CloudFormation
+
+```bash
+aws cloudformation deploy \
+  --template-file examples/sagemaker-marketplace/cloudformation/sagemaker-marketplace-endpoint.yml \
+  --stack-name ds1-sagemaker-endpoint \
+  --region <region> \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    ModelPackageArn=arn:aws:sagemaker:<region>:<account-id>:model-package/<name> \
+    Region=<region>
+
+aws cloudformation describe-stacks \
+  --stack-name ds1-sagemaker-endpoint \
+  --region <region> \
+  --query "Stacks[0].Outputs"
+```
+
+### Deploy with CDK
+
+```bash
+cd examples/sagemaker-marketplace/cdk
+npm install
+npx cdk deploy \
+  --parameters ModelPackageArn=arn:aws:sagemaker:<region>:<account-id>:model-package/<name> \
+  --parameters Region=<region>
+```
+
+`CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` are set automatically from your AWS credentials/profile —
+confirm they match the region your `ModelPackageArn` was issued for. Outputs are printed after deploy
+completes, or re-fetch them any time with:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name SageMakerMarketplaceEndpointStack \
+  --region <region> \
+  --query "Stacks[0].Outputs"
+```
+
+### Advanced: manual deployment
+
+If you can't use CloudFormation/CDK, you can create the execution role, model, endpoint config, and
+endpoint by hand (console or `aws sagemaker create-*` calls) — mirror the resources and settings in
+[`sagemaker-marketplace-endpoint.yml`](../examples/sagemaker-marketplace/cloudformation/sagemaker-marketplace-endpoint.yml)
+exactly, since Miru's setup and error messages assume that shape. This path is unsupported and untested
+against Miru — prefer the template.
+
+## 3. Create an invoke-only AWS profile (admin runbook)
+
+This is separate from the endpoint's execution role above — it's the identity **you or your CI** use to
+call the endpoint from `miru setup` / indexing / search. You need an AWS identity that can call
+`sagemaker:InvokeEndpoint` on the endpoint ARN from step 2. The simplest path for a laptop / CI user is a
+**least-privilege IAM user** scoped to that one endpoint, installed as a named profile.
+
+From a checkout of this repo, with the [AWS CLI](https://docs.aws.amazon.com/cli/) available and **admin**
+credentials in your current shell:
 
 ```bash
 bun run sagemaker:create-invoke-user -- \
@@ -59,7 +143,8 @@ That script (`scripts/create-sagemaker-invoke-user.ts`):
 
 Optional flags: `--user-name <name>`, `--profile <name>` (alias: `--arn` for the endpoint).
 
-Prefer SSO / IAM roles in production if your org requires it — the runbook script is the easy start with long-lived keys. Rotate or delete keys when someone leaves.
+Prefer SSO / IAM roles in production if your org requires it — the runbook script is the easy start with
+long-lived keys. Rotate or delete keys when someone leaves.
 
 Smoke-test invoke (optional):
 
@@ -67,9 +152,7 @@ Smoke-test invoke (optional):
 bun run sagemaker:auth-check -- --arn arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>
 ```
 
-
-
-## 3. Point Miru at the endpoint
+## 4. Point Miru at the endpoint
 
 ```bash
 miru setup --sagemaker \
@@ -77,7 +160,8 @@ miru setup --sagemaker \
   --profile miru
 ```
 
-Or run `miru setup --sagemaker` and answer the prompts.
+Use the `EndpointArn` output from step 2 and the profile from step 3. Or run `miru setup --sagemaker` and
+answer the prompts.
 
 **What setup does**
 
@@ -103,13 +187,11 @@ Also unset any `MIRU_SAGEMAKER_*` variables if you set them in the environment o
 
 Prefer `miru setup --sagemaker` so auth is checked automatically. You can also set:
 
-
 | Variable                                                 | Purpose                                                   |
-| -------------------------------------------------------- | --------------------------------------------------------- |
+| --------------------------------------------------------- | ----------------------------------------------------------- |
 | `MIRU_SAGEMAKER_ENDPOINT_ARN`                            | `arn:aws:sagemaker:<region>:<account-id>:endpoint/<name>` |
 | `MIRU_SAGEMAKER_ENDPOINT_NAME` + `MIRU_SAGEMAKER_REGION` | Alternative to the ARN                                    |
 | `AWS_PROFILE` / `AWS_ACCESS_KEY_ID` / …                  | Standard AWS credential chain                             |
-
 
 Optional TEI-style knobs: `MIRU_SAGEMAKER_NORMALIZE`, `MIRU_SAGEMAKER_TRUNCATE`, `MIRU_SAGEMAKER_TRUNCATION_DIRECTION`, `MIRU_SAGEMAKER_PROMPT_NAME`.
 


### PR DESCRIPTION
## Summary
- Reconciles `docs/self-hosted-sagemaker.md` with the CloudFormation/CDK deployment templates added in PRD-434 (`examples/sagemaker-marketplace`)
- Makes the template deploy (CFN or CDK) the primary/supported setup path, with parameters, created resources, and outputs documented
- Documents the AWS Marketplace subscription prerequisite (`ModelPackageArn`) and how `EndpointArn` feeds into `miru setup --sagemaker`
- Marks manual endpoint creation as an advanced, unsupported fallback instead of the default path

PRD-435

## Test plan
- [x] `docs/self-hosted-sagemaker.md` renders correctly (checked markdown by eye)
- [x] Parameters/outputs table matches `examples/sagemaker-marketplace/cloudformation/sagemaker-marketplace-endpoint.yml` and the CDK stack exactly